### PR TITLE
PR-v1.0.3-UI-1 — UI Facade + rapihin nama + modular

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,18 @@ sfdbtools <command> <subcommand> --help
 - `SFDB_ENCRYPTION_KEY`: default key untuk beberapa perintah `crypto`.
 - `SFDB_SCRIPT_KEY`: key untuk bundle `script`.
 
+## Catatan Pengembang (UI Facade)
+
+Mulai UI-1, seluruh code internal wajib lewat facade `internal/ui/*`:
+
+- Gunakan `internal/ui/print`, `internal/ui/prompt`, `internal/ui/table`, `internal/ui/progress`, `internal/ui/text`, `internal/ui/style`.
+- Package legacy `pkg/ui` dan `pkg/input` hanya boleh di-import oleh facade `internal/ui/*`.
+
+Rencana deprecation bertahap:
+
+- UI-2: pindahkan implementasi UI dari `pkg/ui` / `pkg/input` ke `internal/ui/*` (tanpa mengubah UX), facade tidak lagi sekadar delegasi.
+- UI-3: tandai `pkg/ui` / `pkg/input` sebagai deprecated (doc + lint/CI), lalu phase-out pemakaian internal sepenuhnya.
+
 ## Lisensi
 
 Internal Tool DataOn.

--- a/cmd/backup/filter.go
+++ b/cmd/backup/filter.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	defaultVal "sfDBTools/internal/cli/defaults"
 	"sfDBTools/internal/cli/flags"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
 	"sfDBTools/pkg/validation"
 
 	"github.com/spf13/cobra"
@@ -61,8 +61,7 @@ func getBackupMode(cmd *cobra.Command) (string, error) {
 			"multi-file (pisahkan setiap database ke file terpisah)",
 		}
 
-		var selected string
-		selected, err := input.SelectSingleFromListWithDefault(modeOptions, "Pilih mode backup:", modeOptions[0])
+		selected, _, err := prompt.SelectOne("Pilih mode backup:", modeOptions, 0)
 		if err != nil {
 			return "", fmt.Errorf("mode non-interaktif: set --mode secara eksplisit (single-file/multi-file): %w", validation.HandleInputError(err))
 		}

--- a/cmd/jobs/main.go
+++ b/cmd/jobs/main.go
@@ -12,7 +12,7 @@ import (
 
 	internaljobs "sfDBTools/internal/jobs"
 	"sfDBTools/internal/services/scheduler"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/validation"
 
 	"github.com/spf13/cobra"
@@ -27,7 +27,7 @@ var CmdJobs = &cobra.Command{
 
 Default akan menampilkan daftar service dan timer yang relevan tanpa user perlu mengetik systemctl/journalctl manual.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ui.Headers("SYSTEMD JOBS")
+		print.PrintAppHeader("SYSTEMD JOBS")
 		if internaljobs.IsInteractiveAllowed() {
 			scope, err := getScope(cmd)
 			if err != nil {
@@ -47,8 +47,8 @@ var cmdJobsList = &cobra.Command{
 	Use:   "list",
 	Short: "Tampilkan daftar unit service & timer",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ui.Headers("SYSTEMD JOBS")
-		ui.PrintSubHeader("List")
+		print.PrintAppHeader("SYSTEMD JOBS")
+		print.PrintSubHeader("List")
 		scope, err := getScope(cmd)
 		if err != nil {
 			return err
@@ -66,8 +66,8 @@ var cmdJobsStatus = &cobra.Command{
 	Short: "Tampilkan status detail unit",
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ui.Headers("SYSTEMD JOBS")
-		ui.PrintSubHeader("Status")
+		print.PrintAppHeader("SYSTEMD JOBS")
+		print.PrintSubHeader("Status")
 		scope, err := getScope(cmd)
 		if err != nil {
 			return err
@@ -83,7 +83,7 @@ var cmdJobsStatus = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		ui.PrintInfo(fmt.Sprintf("Scope: %s", used))
+		print.PrintInfo(fmt.Sprintf("Scope: %s", used))
 		fmt.Print(out)
 		return nil
 	},
@@ -94,8 +94,8 @@ var cmdJobsLogs = &cobra.Command{
 	Short: "Tampilkan log unit (journalctl)",
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ui.Headers("SYSTEMD JOBS")
-		ui.PrintSubHeader("Logs")
+		print.PrintAppHeader("SYSTEMD JOBS")
+		print.PrintSubHeader("Logs")
 		scope, err := getScope(cmd)
 		if err != nil {
 			return err
@@ -113,7 +113,7 @@ var cmdJobsLogs = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		ui.PrintInfo(fmt.Sprintf("Scope: %s", used))
+		print.PrintInfo(fmt.Sprintf("Scope: %s", used))
 		fmt.Print(out)
 		return nil
 	},
@@ -124,8 +124,8 @@ var cmdJobsStop = &cobra.Command{
 	Short: "Stop unit",
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ui.Headers("SYSTEMD JOBS")
-		ui.PrintSubHeader("Stop")
+		print.PrintAppHeader("SYSTEMD JOBS")
+		print.PrintSubHeader("Stop")
 		scope, err := getScope(cmd)
 		if err != nil {
 			return err
@@ -141,9 +141,9 @@ var cmdJobsStop = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		ui.PrintInfo(fmt.Sprintf("Scope: %s", used))
+		print.PrintInfo(fmt.Sprintf("Scope: %s", used))
 		fmt.Print(out)
-		ui.PrintSuccess("Stop command dikirim")
+		print.PrintSuccess("Stop command dikirim")
 		return nil
 	},
 }
@@ -153,8 +153,8 @@ var cmdJobsRemove = &cobra.Command{
 	Short: "Hapus job (stop/disable + reset-failed + optional purge unit file)",
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ui.Headers("SYSTEMD JOBS")
-		ui.PrintSubHeader("Remove")
+		print.PrintAppHeader("SYSTEMD JOBS")
+		print.PrintSubHeader("Remove")
 		scope, err := getScope(cmd)
 		if err != nil {
 			return err
@@ -174,7 +174,7 @@ var cmdJobsRemove = &cobra.Command{
 				if out != "" {
 					fmt.Print(out)
 				}
-				ui.PrintSuccess("Remove selesai")
+				print.PrintSuccess("Remove selesai")
 				return nil
 			}
 			return fmt.Errorf("mode non-interaktif (--quiet): unit wajib diisi; contoh: sfdbtools jobs remove <unit>: %w", validation.ErrNonInteractive)
@@ -183,11 +183,11 @@ var cmdJobsRemove = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		ui.PrintInfo(fmt.Sprintf("Scope: %s", used))
+		print.PrintInfo(fmt.Sprintf("Scope: %s", used))
 		if out != "" {
 			fmt.Print(out)
 		}
-		ui.PrintSuccess("Remove selesai")
+		print.PrintSuccess("Remove selesai")
 		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,8 +18,8 @@ import (
 	restorecmd "sfDBTools/cmd/restore"
 	scriptcmd "sfDBTools/cmd/script"
 	appdeps "sfDBTools/internal/cli/deps"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/runtimecfg"
-	"sfDBTools/pkg/ui"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -72,7 +72,7 @@ Didesain untuk keandalan dan penggunaan di lingkungan produksi.`,
 
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("Silakan jalankan 'sfdbtools --help' untuk melihat perintah yang tersedia.")
-		ui.PrintSeparator()
+		print.PrintSeparator()
 		cmd.Help()
 	},
 }

--- a/cmd/script/extract.go
+++ b/cmd/script/extract.go
@@ -6,7 +6,7 @@ import (
 	"sfDBTools/internal/cli/deps"
 	"sfDBTools/internal/cli/flags"
 	"sfDBTools/internal/cli/parsing"
-	"sfDBTools/pkg/input"
+	"sfDBTools/internal/ui/prompt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -41,7 +41,7 @@ sfdbtools script extract -f /etc/sfDBTools/scripts/tes.sftools -o ./tes_extracte
 		if strings.TrimSpace(opts.OutDir) == "" {
 			base := strings.TrimSuffix(filepath.Base(opts.FilePath), filepath.Ext(opts.FilePath))
 			defaultOut := "./" + base + "_extracted"
-			out, err := input.AskString("Output directory untuk hasil extract", defaultOut, nil)
+			out, err := prompt.AskText("Output directory untuk hasil extract", prompt.WithDefault(defaultOut))
 			if err != nil {
 				deps.Deps.Logger.Error(err.Error())
 				return

--- a/cmd/script/run.go
+++ b/cmd/script/run.go
@@ -8,7 +8,7 @@ import (
 	"sfDBTools/internal/cli/deps"
 	"sfDBTools/internal/cli/flags"
 	"sfDBTools/internal/cli/parsing"
-	"sfDBTools/pkg/input"
+	"sfDBTools/internal/ui/prompt"
 	"sort"
 	"strings"
 
@@ -48,7 +48,7 @@ sfdbtools script run -f tes -k "mypassword" -- --mode 1
 
 			// Interaktif: jika user belum provide args via CLI (`-- ...`), tanyakan args opsional.
 			if len(opts.Args) == 0 {
-				line, err := input.PromptString("Masukkan args untuk script (opsional, pisahkan dengan spasi; kosongkan jika tidak ada)")
+				line, err := prompt.AskText("Masukkan args untuk script (opsional, pisahkan dengan spasi; kosongkan jika tidak ada)")
 				if err != nil {
 					deps.Deps.Logger.Error(err.Error())
 					return
@@ -101,7 +101,7 @@ func selectSFToolsFileInteractive() (string, error) {
 		items, err := listSFToolsFiles(configuredDir)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
-			return input.SelectFileInteractive(".", "Cari file .sftools yang akan dijalankan", []string{".sftools"})
+			return prompt.SelectFile(".", "Cari file .sftools yang akan dijalankan", []string{".sftools"})
 		}
 		if len(items) > 0 {
 			const browseLabel = "🔎 Cari manual (browse)"
@@ -110,16 +110,16 @@ func selectSFToolsFileInteractive() (string, error) {
 			options := append([]string{}, items...)
 			options = append(options, browseLabel, inputLabel)
 
-			selected, err := selectSingleFromListWithDefault(options, fmt.Sprintf("Pilih file .sftools (default dari config: %s)", configuredDir), items[0])
+			selected, _, err := prompt.SelectOne(fmt.Sprintf("Pilih file .sftools (default dari config: %s)", configuredDir), options, 0)
 			if err != nil {
 				return "", err
 			}
 			switch selected {
 			case browseLabel:
-				return input.SelectFileInteractive(configuredDir, "Cari file .sftools yang akan dijalankan", []string{".sftools"})
+				return prompt.SelectFile(configuredDir, "Cari file .sftools yang akan dijalankan", []string{".sftools"})
 			case inputLabel:
 				for {
-					p, err := input.PromptString("Masukkan path file .sftools")
+					p, err := prompt.AskText("Masukkan path file .sftools")
 					if err != nil {
 						return "", err
 					}
@@ -141,11 +141,7 @@ func selectSFToolsFileInteractive() (string, error) {
 	}
 
 	// Fallback: browse dari current dir (tetap bisa ketik path bebas).
-	return input.SelectFileInteractive(".", "Pilih file .sftools yang akan dijalankan", []string{".sftools"})
-}
-
-func selectSingleFromListWithDefault(items []string, message string, defaultVal string) (string, error) {
-	return input.SelectSingleFromListWithDefault(items, message, defaultVal)
+	return prompt.SelectFile(".", "Pilih file .sftools yang akan dijalankan", []string{".sftools"})
 }
 
 func listSFToolsFiles(dir string) ([]string, error) {

--- a/internal/app/backup/command.go
+++ b/internal/app/backup/command.go
@@ -16,9 +16,10 @@ import (
 	appdeps "sfDBTools/internal/cli/deps"
 	"sfDBTools/internal/cli/parsing"
 	"sfDBTools/internal/services/scheduler"
-	"sfDBTools/pkg/consts"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/style"
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/runtimecfg"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 	"syscall"
 	"time"
@@ -80,7 +81,7 @@ func (s *Service) ExecuteBackupCommand(ctx context.Context, config types_backup.
 	// Print success message jika ada
 	if config.SuccessMsg != "" {
 		if !runtimecfg.IsQuiet() && !runtimecfg.IsDaemon() {
-			ui.PrintSuccess(config.SuccessMsg)
+			print.PrintSuccess(config.SuccessMsg)
 		}
 		s.Log.Info(config.SuccessMsg)
 	}
@@ -127,15 +128,15 @@ func executeBackupWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, con
 			return runErr
 		}
 
-		ui.PrintHeader("DB BACKUP - BACKGROUND MODE")
-		ui.PrintSuccess("Background backup dimulai via systemd")
-		ui.PrintInfo(fmt.Sprintf("Unit: %s", ui.ColorText(res.UnitName, consts.UIColorCyan)))
+		print.PrintHeader("DB BACKUP - BACKGROUND MODE")
+		print.PrintSuccess("Background backup dimulai via systemd")
+		print.PrintInfo(fmt.Sprintf("Unit: %s", text.Color(res.UnitName, style.ColorCyan)))
 		if res.Mode == scheduler.RunModeUser {
-			ui.PrintInfo(fmt.Sprintf("Status: systemctl --user status %s", res.UnitName))
-			ui.PrintInfo(fmt.Sprintf("Logs: journalctl --user -u %s -f", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Status: systemctl --user status %s", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Logs: journalctl --user -u %s -f", res.UnitName))
 		} else {
-			ui.PrintInfo(fmt.Sprintf("Status: sudo systemctl status %s", res.UnitName))
-			ui.PrintInfo(fmt.Sprintf("Logs: sudo journalctl -u %s -f", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Status: sudo systemctl status %s", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Logs: sudo journalctl -u %s -f", res.UnitName))
 		}
 		return nil
 	}
@@ -165,7 +166,7 @@ func executeBackupWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, con
 	go func() {
 		sig := <-sigChan
 		if !runtimecfg.IsQuiet() && !runtimecfg.IsDaemon() {
-			fmt.Println()
+			print.Println()
 		}
 		logger.Warnf("Menerima signal %v, menghentikan backup... (Tekan sekali lagi untuk force exit)", sig)
 		svc.HandleShutdown()
@@ -173,7 +174,7 @@ func executeBackupWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, con
 
 		<-sigChan
 		if !runtimecfg.IsQuiet() && !runtimecfg.IsDaemon() {
-			fmt.Println()
+			print.Println()
 		}
 		logger.Warn("Menerima signal kedua, memaksa berhenti (force exit)...")
 		os.Exit(1)

--- a/internal/app/backup/display/options_displayer.go
+++ b/internal/app/backup/display/options_displayer.go
@@ -2,8 +2,9 @@ package display
 
 import (
 	"sfDBTools/internal/app/backup/model/types_backup"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
+	"sfDBTools/internal/ui/table"
 	"sfDBTools/pkg/validation"
 )
 
@@ -18,7 +19,7 @@ func NewOptionsDisplayer(options *types_backup.BackupDBOptions) *OptionsDisplaye
 }
 
 func (d *OptionsDisplayer) renderTable() {
-	ui.PrintSubHeader("Opsi Backup")
+	print.PrintSubHeader("Opsi Backup")
 
 	data := [][]string{}
 	data = append(data, d.buildGeneralSection()...)
@@ -28,7 +29,7 @@ func (d *OptionsDisplayer) renderTable() {
 	data = append(data, d.buildCompressionSection()...)
 	data = append(data, d.buildEncryptionSection()...)
 
-	ui.FormatTable([]string{"Parameter", "Value"}, data)
+	table.Render([]string{"Parameter", "Value"}, data)
 }
 
 // Render menampilkan backup options tanpa meminta konfirmasi.
@@ -40,7 +41,7 @@ func (d *OptionsDisplayer) Render() {
 func (d *OptionsDisplayer) Display() (bool, error) {
 	d.renderTable()
 
-	confirm, err := input.AskYesNo("Apakah Anda ingin melanjutkan?", true)
+	confirm, err := prompt.Confirm("Apakah Anda ingin melanjutkan?", true)
 	if err != nil {
 		return false, err
 	}

--- a/internal/app/backup/display/options_helpers.go
+++ b/internal/app/backup/display/options_helpers.go
@@ -1,8 +1,8 @@
 package display
 
 import (
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 )
 
 func (d *OptionsDisplayer) isSingleMode() bool {
@@ -17,7 +17,7 @@ func (d *OptionsDisplayer) getExportUserStatus() string {
 	if d.options.ExcludeUser {
 		return "No"
 	}
-	return ui.ColorText("Yes", consts.UIColorGreen)
+	return text.ColorText("Yes", consts.UIColorGreen)
 }
 
 func (d *OptionsDisplayer) getFilenameLabel() string {

--- a/internal/app/backup/display/options_sections.go
+++ b/internal/app/backup/display/options_sections.go
@@ -2,15 +2,15 @@ package display
 
 import (
 	"fmt"
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 	"sort"
 )
 
 func (d *OptionsDisplayer) buildGeneralSection() [][]string {
 	data := [][]string{
-		{"Mode Backup", ui.ColorText(d.options.Mode, consts.UIColorCyan)},
-		{"Ticket", ui.ColorText(d.options.Ticket, consts.UIColorYellow)},
+		{"Mode Backup", text.ColorText(d.options.Mode, consts.UIColorCyan)},
+		{"Ticket", text.ColorText(d.options.Ticket, consts.UIColorYellow)},
 		{"Output Directory", d.options.OutputDir},
 	}
 
@@ -18,10 +18,10 @@ func (d *OptionsDisplayer) buildGeneralSection() [][]string {
 	// - Mode single/primary/secondary/combined/all: tampilkan filename akurat
 	// - Mode separated dengan filter: tampilkan contoh filename
 	if d.isSeparatedMode() {
-		data = append(data, []string{"Filename Example", ui.ColorText(d.options.File.Path, consts.UIColorCyan)})
+		data = append(data, []string{"Filename Example", text.ColorText(d.options.File.Path, consts.UIColorCyan)})
 	} else if d.isSingleMode() || d.options.Mode == consts.ModeCombined || d.options.Mode == consts.ModeAll {
 		label := d.getFilenameLabel()
-		data = append(data, []string{label, ui.ColorText(d.options.File.Path, consts.UIColorCyan)})
+		data = append(data, []string{label, text.ColorText(d.options.File.Path, consts.UIColorCyan)})
 	}
 
 	data = append(data, []string{"Dry Run", fmt.Sprintf("%v", d.options.DryRun)})
@@ -33,9 +33,9 @@ func (d *OptionsDisplayer) buildModeSpecificSection() [][]string {
 		data := [][]string{}
 
 		if d.options.Mode == consts.ModeAll {
-			data = append(data, []string{"Metode Filter", ui.ColorText("Exclude (semua kecuali yang dikecualikan)", consts.UIColorYellow)})
+			data = append(data, []string{"Metode Filter", text.ColorText("Exclude (semua kecuali yang dikecualikan)", consts.UIColorYellow)})
 		} else if d.options.Mode == consts.ModeCombined {
-			data = append(data, []string{"Metode Filter", ui.ColorText("Include (hanya yang dipilih)", consts.UIColorYellow)})
+			data = append(data, []string{"Metode Filter", text.ColorText("Include (hanya yang dipilih)", consts.UIColorYellow)})
 		}
 
 		if d.options.Mode == consts.ModeCombined || d.options.Mode == consts.ModeAll {
@@ -52,7 +52,7 @@ func (d *OptionsDisplayer) buildModeSpecificSection() [][]string {
 	if dbName == "" {
 		dbName = "<belum dipilih>"
 	}
-	data = append(data, []string{"Database Utama", ui.ColorText(dbName, consts.UIColorYellow)})
+	data = append(data, []string{"Database Utama", text.ColorText(dbName, consts.UIColorYellow)})
 
 	if d.options.File.Filename != "" {
 		data = append(data, []string{"Custom Filename", d.options.File.Filename})
@@ -86,7 +86,7 @@ func (d *OptionsDisplayer) buildCompanionStatus() [][]string {
 			status = "tidak ditemukan"
 			color = consts.UIColorRed
 		}
-		data = append(data, []string{"  - " + name, ui.ColorText(status, color)})
+		data = append(data, []string{"  - " + name, text.ColorText(status, color)})
 	}
 
 	return data
@@ -98,7 +98,7 @@ func (d *OptionsDisplayer) buildProfileSection() [][]string {
 	}
 
 	return [][]string{
-		{"Profile", ui.ColorText(d.options.Profile.Name, consts.UIColorYellow)},
+		{"Profile", text.ColorText(d.options.Profile.Name, consts.UIColorYellow)},
 		{"HostName", d.options.Profile.DBInfo.HostName},
 		{"Host", fmt.Sprintf("%s:%d", d.options.Profile.DBInfo.Host, d.options.Profile.DBInfo.Port)},
 		{"User", d.options.Profile.DBInfo.User},
@@ -108,7 +108,7 @@ func (d *OptionsDisplayer) buildProfileSection() [][]string {
 func (d *OptionsDisplayer) buildFilterSection() [][]string {
 	data := [][]string{
 		{"", ""},
-		{ui.ColorText("Filter Options", consts.UIColorPurple), ""},
+		{text.ColorText("Filter Options", consts.UIColorPurple), ""},
 	}
 
 	if !d.isSingleMode() {
@@ -154,7 +154,7 @@ func (d *OptionsDisplayer) buildDatabaseList(label string, databases []string) [
 func (d *OptionsDisplayer) buildCompressionSection() [][]string {
 	data := [][]string{
 		{"", ""},
-		{ui.ColorText("Compression", consts.UIColorPurple), ""},
+		{text.ColorText("Compression", consts.UIColorPurple), ""},
 		{"Enabled", fmt.Sprintf("%v", d.options.Compression.Enabled)},
 	}
 
@@ -169,14 +169,14 @@ func (d *OptionsDisplayer) buildCompressionSection() [][]string {
 func (d *OptionsDisplayer) buildEncryptionSection() [][]string {
 	data := [][]string{
 		{"", ""},
-		{ui.ColorText("Encryption", consts.UIColorPurple), ""},
+		{text.ColorText("Encryption", consts.UIColorPurple), ""},
 		{"Enabled", fmt.Sprintf("%v", d.options.Encryption.Enabled)},
 	}
 
 	if d.options.Encryption.Enabled {
-		statusText := ui.ColorText("Missing", consts.UIColorRed)
+		statusText := text.ColorText("Missing", consts.UIColorRed)
 		if d.options.Encryption.Key != "" {
-			statusText = ui.ColorText("Configured", consts.UIColorGreen)
+			statusText = text.ColorText("Configured", consts.UIColorGreen)
 		}
 		data = append(data, []string{"Key Status", statusText})
 	}

--- a/internal/app/backup/display/result_display.go
+++ b/internal/app/backup/display/result_display.go
@@ -9,8 +9,10 @@ package display
 import (
 	"fmt"
 	"sfDBTools/internal/app/backup/model/types_backup"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/table"
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 )
 
 // ResultDisplayer handles display of backup results
@@ -33,7 +35,7 @@ func NewResultDisplayer(result *types_backup.BackupResult, compressionEnabled bo
 
 // Display menampilkan hasil backup
 func (d *ResultDisplayer) Display() {
-	ui.PrintSubHeader("Hasil Backup Database")
+	print.PrintSubHeader("Hasil Backup Database")
 
 	d.displaySummary()
 	d.displaySuccessDetails()
@@ -44,11 +46,11 @@ func (d *ResultDisplayer) Display() {
 func (d *ResultDisplayer) displaySummary() {
 	data := [][]string{
 		{"Total Database Ditemukan", fmt.Sprintf("%d", d.result.TotalDatabases)},
-		{"Total Database Dibackup", ui.ColorText(fmt.Sprintf("%d", d.result.SuccessfulBackups), consts.UIColorGreen)},
-		{"Total Gagal Dibackup", ui.ColorText(fmt.Sprintf("%d", d.result.FailedBackups), consts.UIColorRed)},
-		{"Total Waktu Proses", ui.ColorText(d.result.TotalTimeTaken.String(), consts.UIColorCyan)},
+		{"Total Database Dibackup", text.ColorText(fmt.Sprintf("%d", d.result.SuccessfulBackups), consts.UIColorGreen)},
+		{"Total Gagal Dibackup", text.ColorText(fmt.Sprintf("%d", d.result.FailedBackups), consts.UIColorRed)},
+		{"Total Waktu Proses", text.ColorText(d.result.TotalTimeTaken.String(), consts.UIColorCyan)},
 	}
-	ui.FormatTable([]string{"Kategori", "Jumlah"}, data)
+	table.Render([]string{"Kategori", "Jumlah"}, data)
 }
 
 // displaySuccessDetails menampilkan detail backup yang berhasil
@@ -57,7 +59,7 @@ func (d *ResultDisplayer) displaySuccessDetails() {
 		return
 	}
 
-	ui.PrintSubHeader("Detail Backup yang Berhasil")
+	print.PrintSubHeader("Detail Backup yang Berhasil")
 
 	for _, info := range d.result.BackupInfo {
 		fmt.Println()
@@ -68,7 +70,7 @@ func (d *ResultDisplayer) displaySuccessDetails() {
 // displayBackupInfo menampilkan detail satu backup info
 func (d *ResultDisplayer) displayBackupInfo(info types_backup.DatabaseBackupInfo) {
 	data := [][]string{
-		{"Database", ui.ColorText(info.DatabaseName, consts.UIColorCyan)},
+		{"Database", text.ColorText(info.DatabaseName, consts.UIColorCyan)},
 		{"Status", d.formatStatus(info.Status)},
 		{"File Output", info.OutputFile},
 		{"Ukuran File", info.FileSizeHuman},
@@ -82,12 +84,12 @@ func (d *ResultDisplayer) displayBackupInfo(info types_backup.DatabaseBackupInfo
 	data = append(data, d.buildCompressionRow())
 	data = append(data, d.buildEncryptionRow())
 
-	ui.FormatTable([]string{"Parameter", "Nilai"}, data)
+	table.Render([]string{"Parameter", "Nilai"}, data)
 
 	// Tampilkan warning jika ada
 	if info.Warnings != "" {
-		ui.PrintWarning("\n⚠ Warning dari mysqldump:")
-		fmt.Println(ui.ColorText(info.Warnings, consts.UIColorYellow))
+		print.PrintWarn("\n⚠ Warning dari mysqldump:")
+		fmt.Println(text.ColorText(info.Warnings, consts.UIColorYellow))
 	}
 }
 
@@ -96,19 +98,19 @@ func (d *ResultDisplayer) buildMetadataRows(info types_backup.DatabaseBackupInfo
 	rows := [][]string{}
 
 	if info.BackupID != "" {
-		rows = append(rows, []string{"Backup ID", ui.ColorText(info.BackupID, consts.UIColorYellow)})
+		rows = append(rows, []string{"Backup ID", text.ColorText(info.BackupID, consts.UIColorYellow)})
 	}
 	if !info.StartTime.IsZero() {
-		rows = append(rows, []string{"Start Time", ui.ColorText(info.StartTime.String(), consts.UIColorCyan)})
+		rows = append(rows, []string{"Start Time", text.ColorText(info.StartTime.String(), consts.UIColorCyan)})
 	}
 	if !info.EndTime.IsZero() {
-		rows = append(rows, []string{"End Time", ui.ColorText(info.EndTime.String(), consts.UIColorCyan)})
+		rows = append(rows, []string{"End Time", text.ColorText(info.EndTime.String(), consts.UIColorCyan)})
 	}
 	if info.ThroughputMBps > 0 {
-		rows = append(rows, []string{"Throughput", ui.ColorText(fmt.Sprintf("%.2f MB/s", info.ThroughputMBps), consts.UIColorGreen)})
+		rows = append(rows, []string{"Throughput", text.ColorText(fmt.Sprintf("%.2f MB/s", info.ThroughputMBps), consts.UIColorGreen)})
 	}
 	if info.ManifestFile != "" {
-		rows = append(rows, []string{"Manifest", ui.ColorText(info.ManifestFile, consts.UIColorPurple)})
+		rows = append(rows, []string{"Manifest", text.ColorText(info.ManifestFile, consts.UIColorPurple)})
 	}
 
 	return rows
@@ -117,17 +119,17 @@ func (d *ResultDisplayer) buildMetadataRows(info types_backup.DatabaseBackupInfo
 // buildCompressionRow builds compression info row
 func (d *ResultDisplayer) buildCompressionRow() []string {
 	if d.compressionEnabled {
-		return []string{"Kompresi", ui.ColorText("Enabled ("+d.compressionType+")", consts.UIColorGreen)}
+		return []string{"Kompresi", text.ColorText("Enabled ("+d.compressionType+")", consts.UIColorGreen)}
 	}
-	return []string{"Kompresi", ui.ColorText("Disabled", consts.UIColorYellow)}
+	return []string{"Kompresi", text.ColorText("Disabled", consts.UIColorYellow)}
 }
 
 // buildEncryptionRow builds encryption info row
 func (d *ResultDisplayer) buildEncryptionRow() []string {
 	if d.encryptionEnabled {
-		return []string{"Enkripsi", ui.ColorText("Enabled", consts.UIColorGreen)}
+		return []string{"Enkripsi", text.ColorText("Enabled", consts.UIColorGreen)}
 	}
-	return []string{"Enkripsi", ui.ColorText("Disabled", consts.UIColorYellow)}
+	return []string{"Enkripsi", text.ColorText("Disabled", consts.UIColorYellow)}
 }
 
 // displayFailures menampilkan daftar database yang gagal
@@ -136,17 +138,17 @@ func (d *ResultDisplayer) displayFailures() {
 		return
 	}
 
-	ui.PrintSubHeader("Daftar Database Gagal Dibackup")
+	print.PrintSubHeader("Daftar Database Gagal Dibackup")
 
 	if len(d.result.FailedDatabaseInfos) > 0 {
 		for i, failedInfo := range d.result.FailedDatabaseInfos {
-			fmt.Printf("%d. %s\n", i+1, ui.ColorText(failedInfo.DatabaseName, consts.UIColorRed))
+			fmt.Printf("%d. %s\n", i+1, text.ColorText(failedInfo.DatabaseName, consts.UIColorRed))
 			fmt.Printf("   Error: %s\n", failedInfo.Error)
 			fmt.Println()
 		}
 	} else if len(d.result.FailedDatabases) > 0 {
 		for dbName, errMsg := range d.result.FailedDatabases {
-			ui.PrintError("- " + dbName + ": " + errMsg)
+			print.PrintError("- " + dbName + ": " + errMsg)
 		}
 	}
 }
@@ -154,7 +156,7 @@ func (d *ResultDisplayer) displayFailures() {
 // formatStatus formats backup status dengan warna
 func (d *ResultDisplayer) formatStatus(status string) string {
 	if status == consts.BackupStatusSuccessWithWarnings {
-		return ui.ColorText("Sukses dengan Warning", consts.UIColorYellow)
+		return text.ColorText("Sukses dengan Warning", consts.UIColorYellow)
 	}
-	return ui.ColorText(status, consts.UIColorGreen)
+	return text.ColorText(status, consts.UIColorGreen)
 }

--- a/internal/app/backup/path_helpers.go
+++ b/internal/app/backup/path_helpers.go
@@ -5,10 +5,10 @@ import (
 	"path/filepath"
 	"sfDBTools/internal/app/backup/modes"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/database"
 	pkghelper "sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -105,7 +105,7 @@ func (s *Service) GenerateBackupPaths(ctx context.Context, client *database.Clie
 			TotalExcluded:     len(allDatabases) - len(dbFiltered),
 			ExcludedDatabases: s.excludedDatabases,
 		}
-		ui.DisplayFilterStats(stats, consts.FeatureBackup, s.Log)
+		print.PrintFilterStats(stats, consts.FeatureBackup, s.Log)
 	}
 
 	// Jika user set custom filename untuk mode all/combined, treat sebagai base name tanpa ekstensi.

--- a/internal/app/backup/service.go
+++ b/internal/app/backup/service.go
@@ -13,13 +13,14 @@ import (
 	"sfDBTools/internal/domain"
 	appconfig "sfDBTools/internal/services/config"
 	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/progress"
 	"sfDBTools/pkg/backuphelper"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/database"
 	"sfDBTools/pkg/errorlog"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/servicehelper"
-	"sfDBTools/pkg/ui"
 )
 
 // Service adalah service utama untuk backup operations
@@ -134,19 +135,19 @@ func (s *Service) HandleShutdown() {
 	})
 
 	if shouldRemoveFile {
-		ui.RunWithSpinnerSuspended(func() {
+		progress.RunWithSpinnerSuspended(func() {
 			s.Log.Warn("Proses backup dihentikan, melakukan rollback...")
 			if err := fsops.RemoveFile(fileToRemove); err != nil {
 				s.Log.Errorf("Gagal menghapus file backup: %v", err)
-				ui.PrintError(fmt.Sprintf("⚠ WARNING: File backup partial mungkin masih tersisa: %s", fileToRemove))
-				ui.PrintError("Silakan hapus manual jika diperlukan.")
+				print.PrintError(fmt.Sprintf("⚠ WARNING: File backup partial mungkin masih tersisa: %s", fileToRemove))
+				print.PrintError("Silakan hapus manual jika diperlukan.")
 			} else {
 				s.Log.Infof("File backup yang belum selesai berhasil dihapus: %s", fileToRemove)
 				s.Log.Info("File backup partial berhasil dihapus")
 			}
 		})
 	} else {
-		ui.RunWithSpinnerSuspended(func() {
+		progress.RunWithSpinnerSuspended(func() {
 			s.Log.Warn("Menerima signal interrupt, tidak ada proses backup aktif")
 		})
 	}

--- a/internal/app/backup/setup/config.go
+++ b/internal/app/backup/setup/config.go
@@ -7,11 +7,11 @@ import (
 	"sfDBTools/internal/app/backup/model/types_backup"
 	appconfig "sfDBTools/internal/services/config"
 	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/fsops"
 	profilehelper "sfDBTools/pkg/helper/profile"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 )
 
 type Setup struct {
@@ -64,14 +64,14 @@ func (s *Setup) CheckAndSelectConfigFile() error {
 
 // SetupBackupExecution prepares common backup execution settings (ticket, output dir, logging).
 func (s *Setup) SetupBackupExecution() error {
-	ui.PrintSubHeader("Persiapan Eksekusi Backup")
+	print.PrintSubHeader("Persiapan Eksekusi Backup")
 
 	if strings.TrimSpace(s.Options.Ticket) == "" {
 		if s.Options.NonInteractive {
 			return fmt.Errorf("ticket wajib diisi pada mode non-interaktif (--quiet): gunakan --ticket")
 		}
 		s.Log.Info("Ticket number tidak ditemukan, meminta input...")
-		ticket, err := input.AskTicket(consts.FeatureBackup)
+		ticket, err := prompt.AskTicket(consts.FeatureBackup)
 		if err != nil {
 			return fmt.Errorf("gagal mendapatkan ticket number: %w", err)
 		}

--- a/internal/app/backup/setup/edit_menu_engine.go
+++ b/internal/app/backup/setup/edit_menu_engine.go
@@ -2,14 +2,14 @@
 // Deskripsi : Engine menu terpusat untuk edit opsi backup (interactive)
 // Author : Hadiyatna Muflihun
 // Tanggal : 2025-12-31
-// Last Modified : 2025-12-31
+// Last Modified : 2026-01-05
 
 package setup
 
 import (
 	"fmt"
 
-	"sfDBTools/pkg/input"
+	"sfDBTools/internal/ui/prompt"
 )
 
 type editMenuItem struct {
@@ -27,7 +27,7 @@ func (s *Setup) runEditMenuInteractive(items []editMenuItem) error {
 	}
 	options = append(options, "Kembali")
 
-	choice, err := input.SelectSingleFromList(options, "Pilih opsi yang ingin diubah")
+	choice, _, err := prompt.SelectOne("Pilih opsi yang ingin diubah", options, -1)
 	if err != nil {
 		return fmt.Errorf("gagal memilih opsi untuk diubah: %w", err)
 	}

--- a/internal/app/backup/setup/filter.go
+++ b/internal/app/backup/setup/filter.go
@@ -7,8 +7,8 @@ import (
 	"sfDBTools/internal/app/backup/model/types_backup"
 	"sfDBTools/internal/app/backup/selection"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/database"
-	"sfDBTools/pkg/ui"
 )
 
 // GetFilteredDatabases fetches and filters DB list.
@@ -44,37 +44,37 @@ func filterFromBackupOptions(ctx context.Context, client *database.Client, opts 
 }
 
 func (s *Setup) DisplayFilterWarnings(stats *domain.FilterStats) {
-	ui.PrintWarning("Kemungkinan penyebab:")
+	print.PrintWarning("Kemungkinan penyebab:")
 
 	if stats.TotalExcluded == stats.TotalFound {
-		ui.PrintWarning(fmt.Sprintf("  • Semua database (%d) dikecualikan oleh filter exclude", stats.TotalExcluded))
+		print.PrintWarning(fmt.Sprintf("  • Semua database (%d) dikecualikan oleh filter exclude", stats.TotalExcluded))
 	}
 
 	if len(stats.NotFoundInInclude) > 0 {
-		ui.PrintWarning("  • Database yang diminta di include list tidak ditemukan:")
+		print.PrintWarning("  • Database yang diminta di include list tidak ditemukan:")
 		for _, db := range stats.NotFoundInInclude {
-			ui.PrintWarning(fmt.Sprintf("    - %s", db))
+			print.PrintWarning(fmt.Sprintf("    - %s", db))
 		}
 	}
 
 	if len(stats.NotFoundInWhitelist) > 0 {
-		ui.PrintWarning("  • Database dari whitelist file tidak ditemukan:")
+		print.PrintWarning("  • Database dari whitelist file tidak ditemukan:")
 		for _, db := range stats.NotFoundInWhitelist {
-			ui.PrintWarning(fmt.Sprintf("    - %s", db))
+			print.PrintWarning(fmt.Sprintf("    - %s", db))
 		}
 	}
 
 	if len(stats.NotFoundInExclude) > 0 {
-		ui.PrintWarning("  • Database yang diminta di exclude list tidak ditemukan:")
+		print.PrintWarning("  • Database yang diminta di exclude list tidak ditemukan:")
 		for _, db := range stats.NotFoundInExclude {
-			ui.PrintWarning(fmt.Sprintf("    - %s", db))
+			print.PrintWarning(fmt.Sprintf("    - %s", db))
 		}
 	}
 
 	if len(stats.NotFoundInBlacklist) > 0 {
-		ui.PrintWarning("  • Database dari exclude file tidak ditemukan:")
+		print.PrintWarning("  • Database dari exclude file tidak ditemukan:")
 		for _, db := range stats.NotFoundInBlacklist {
-			ui.PrintWarning(fmt.Sprintf("    - %s", db))
+			print.PrintWarning(fmt.Sprintf("    - %s", db))
 		}
 	}
 }

--- a/internal/app/backup/writer/engine.go
+++ b/internal/app/backup/writer/engine.go
@@ -11,12 +11,12 @@ import (
 
 	"sfDBTools/internal/app/backup/model/types_backup"
 	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/progress"
 	"sfDBTools/pkg/compress"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/encrypt"
 	"sfDBTools/pkg/errorlog"
 	pkghelper "sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 )
 
 func summarizeStderr(stderr string, maxLines int, maxChars int) string {
@@ -151,7 +151,7 @@ func (e *Engine) ExecuteMysqldumpWithPipe(ctx context.Context, mysqldumpArgs []s
 		return nil, err
 	}
 
-	spin := ui.NewSpinnerWithElapsed("Memproses backup database")
+	spin := progress.NewSpinnerWithElapsed("Memproses backup database")
 	spin.Start()
 	defer spin.Stop()
 

--- a/internal/app/backup/writer/monitor.go
+++ b/internal/app/backup/writer/monitor.go
@@ -6,20 +6,20 @@ import (
 	"strings"
 	"time"
 
-	"sfDBTools/internal/services/log"
-	"sfDBTools/pkg/ui"
+	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/progress"
 )
 
 // databaseMonitorWriter wraps an io.Writer to track mysqldump progress per database.
 type databaseMonitorWriter struct {
 	target    io.Writer
-	spinner   *ui.SpinnerWithElapsed
+	spinner   *progress.Spinner
 	log       applog.Logger
 	currentDB string
 	startTime time.Time
 }
 
-func newDatabaseMonitorWriter(target io.Writer, spinner *ui.SpinnerWithElapsed, log applog.Logger) *databaseMonitorWriter {
+func newDatabaseMonitorWriter(target io.Writer, spinner *progress.Spinner, log applog.Logger) *databaseMonitorWriter {
 	return &databaseMonitorWriter{target: target, spinner: spinner, log: log}
 }
 
@@ -60,7 +60,7 @@ func (w *databaseMonitorWriter) onDatabaseSwitch(newDB string) {
 		w.log.Infof("Processing database: %s", newDB)
 	}
 	if w.spinner != nil {
-		w.spinner.UpdateMessage(fmt.Sprintf("Processing %s", newDB))
+		w.spinner.Update(fmt.Sprintf("Processing %s", newDB))
 	}
 }
 

--- a/internal/app/cleanup/command.go
+++ b/internal/app/cleanup/command.go
@@ -15,9 +15,10 @@ import (
 	appdeps "sfDBTools/internal/cli/deps"
 	"sfDBTools/internal/cli/parsing"
 	"sfDBTools/internal/services/scheduler"
-	"sfDBTools/pkg/consts"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/style"
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/runtimecfg"
-	"sfDBTools/pkg/ui"
 
 	"github.com/spf13/cobra"
 )
@@ -71,15 +72,15 @@ func executeCleanupWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, co
 		if runErr != nil {
 			return runErr
 		}
-		ui.PrintHeader("CLEANUP - BACKGROUND MODE")
-		ui.PrintSuccess("Background cleanup dimulai via systemd")
-		ui.PrintInfo(fmt.Sprintf("Unit: %s", ui.ColorText(res.UnitName, consts.UIColorCyan)))
+		print.PrintHeader("CLEANUP - BACKGROUND MODE")
+		print.PrintSuccess("Background cleanup dimulai via systemd")
+		print.PrintInfo(fmt.Sprintf("Unit: %s", text.Color(res.UnitName, style.ColorCyan)))
 		if res.Mode == scheduler.RunModeUser {
-			ui.PrintInfo(fmt.Sprintf("Status: systemctl --user status %s", res.UnitName))
-			ui.PrintInfo(fmt.Sprintf("Logs: journalctl --user -u %s -f", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Status: systemctl --user status %s", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Logs: journalctl --user -u %s -f", res.UnitName))
 		} else {
-			ui.PrintInfo(fmt.Sprintf("Status: sudo systemctl status %s", res.UnitName))
-			ui.PrintInfo(fmt.Sprintf("Logs: sudo journalctl -u %s -f", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Status: sudo systemctl status %s", res.UnitName))
+			print.PrintInfo(fmt.Sprintf("Logs: sudo journalctl -u %s -f", res.UnitName))
 		}
 		return nil
 	}
@@ -96,7 +97,7 @@ func executeCleanupWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, co
 
 	// Tampilkan header jika ada (skip saat quiet/daemon)
 	if config.HeaderTitle != "" && !runtimecfg.IsQuiet() && !runtimecfg.IsDaemon() {
-		ui.Headers(config.HeaderTitle)
+		print.PrintAppHeader(config.HeaderTitle)
 	}
 
 	// Execute cleanup command
@@ -107,7 +108,7 @@ func executeCleanupWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, co
 	// Print success message jika ada (skip stdout saat quiet/daemon)
 	if config.SuccessMsg != "" {
 		if !runtimecfg.IsQuiet() && !runtimecfg.IsDaemon() {
-			ui.PrintSuccess(config.SuccessMsg)
+			print.PrintSuccess(config.SuccessMsg)
 		}
 		logger.Info(config.SuccessMsg)
 	}

--- a/internal/app/cleanup/display.go
+++ b/internal/app/cleanup/display.go
@@ -9,14 +9,15 @@ package cleanup
 import (
 	"fmt"
 	"sfDBTools/internal/app/backup/model/types_backup"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/table"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/global"
-	"sfDBTools/pkg/ui"
 )
 
 // displayCleanupOptions menampilkan konfigurasi cleanup yang akan dijalankan
 func (s *Service) displayCleanupOptions() {
-	ui.PrintSubHeader("Konfigurasi Cleanup")
+	print.PrintSubHeader("Konfigurasi Cleanup")
 
 	data := [][]string{
 		{"Base Directory", s.Config.Backup.Output.BaseDirectory},
@@ -31,7 +32,7 @@ func (s *Service) displayCleanupOptions() {
 		data = append(data, []string{"Schedule", s.Config.Backup.Cleanup.Schedule})
 	}
 
-	ui.FormatTable([]string{"Setting", "Value"}, data)
+	table.Render([]string{"Setting", "Value"}, data)
 }
 
 // logDryRunSummary mencatat ringkasan file yang akan dihapus dalam mode dry-run.

--- a/internal/app/dbscan/display.go
+++ b/internal/app/dbscan/display.go
@@ -11,14 +11,15 @@ import (
 	"sfDBTools/internal/app/dbscan/helpers"
 	dbscanmodel "sfDBTools/internal/app/dbscan/model"
 	"sfDBTools/internal/domain"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
+	"sfDBTools/internal/ui/table"
 	"sfDBTools/pkg/validation"
 )
 
 // DisplayScanOptions menampilkan opsi scanning aktif dan meminta konfirmasi
 func (s *Service) DisplayScanOptions() (bool, error) {
-	ui.PrintSubHeader("Opsi Scanning")
+	print.PrintSubHeader("Opsi Scanning")
 
 	data := [][]string{
 		{"Exclude System DB", fmt.Sprintf("%v", s.ScanOptions.ExcludeSystem)},
@@ -31,10 +32,10 @@ func (s *Service) DisplayScanOptions() (bool, error) {
 		data = append(data, []string{"Source Database", s.ScanOptions.SourceDatabase})
 	}
 
-	ui.FormatTable([]string{"Parameter", "Value"}, data)
+	table.Render([]string{"Parameter", "Value"}, data)
 
 	// Konfirmasi
-	confirm, err := input.AskYesNo("Apakah Anda ingin melanjutkan?", true)
+	confirm, err := prompt.Confirm("Apakah Anda ingin melanjutkan?", true)
 	if err != nil {
 		s.Log.Error("User confirmation error: " + err.Error())
 		return false, err
@@ -51,7 +52,7 @@ func (s *Service) DisplayScanOptions() (bool, error) {
 // Wrapper methods for pkg/dbscanhelper and pkg/ui display functions
 
 func (s *Service) DisplayFilterStats(stats *domain.FilterStats) {
-	ui.DisplayFilterStats(stats, "scan", s.Log)
+	print.PrintFilterStats(stats, "scan", s.Log)
 }
 
 func (s *Service) DisplayScanResult(result *dbscanmodel.ScanResult) {

--- a/internal/app/dbscan/helpers/daemon.go
+++ b/internal/app/dbscan/helpers/daemon.go
@@ -14,8 +14,9 @@ import (
 
 	dbscanmodel "sfDBTools/internal/app/dbscan/model"
 	"sfDBTools/internal/services/scheduler"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 )
 
 func detectUserModeText(mode scheduler.RunMode) string {
@@ -46,20 +47,20 @@ func SpawnScanDaemon(config dbscanmodel.ScanEntryConfig) error {
 		return err
 	}
 
-	ui.PrintHeader("DATABASE SCANNING - BACKGROUND MODE")
-	ui.PrintSuccess("Background process dimulai via systemd")
-	ui.PrintInfo(fmt.Sprintf("Scan ID: %s", ui.ColorText(scanID, consts.UIColorCyan)))
-	ui.PrintInfo(fmt.Sprintf("Unit: %s", ui.ColorText(res.UnitName, consts.UIColorCyan)))
-	ui.PrintInfo(fmt.Sprintf("Mode: %s", ui.ColorText(detectUserModeText(res.Mode), consts.UIColorCyan)))
-	ui.PrintInfo(fmt.Sprintf("Log dir: %s", ui.ColorText(logDir, consts.UIColorCyan)))
+	print.PrintHeader("DATABASE SCANNING - BACKGROUND MODE")
+	print.PrintSuccess("Background process dimulai via systemd")
+	print.PrintInfo(fmt.Sprintf("Scan ID: %s", text.ColorText(scanID, consts.UIColorCyan)))
+	print.PrintInfo(fmt.Sprintf("Unit: %s", text.ColorText(res.UnitName, consts.UIColorCyan)))
+	print.PrintInfo(fmt.Sprintf("Mode: %s", text.ColorText(detectUserModeText(res.Mode), consts.UIColorCyan)))
+	print.PrintInfo(fmt.Sprintf("Log dir: %s", text.ColorText(logDir, consts.UIColorCyan)))
 	if res.Mode == scheduler.RunModeUser {
-		ui.PrintInfo(fmt.Sprintf("Status: systemctl --user status %s", res.UnitName))
-		ui.PrintInfo(fmt.Sprintf("Logs: journalctl --user -u %s -f", res.UnitName))
+		print.PrintInfo(fmt.Sprintf("Status: systemctl --user status %s", res.UnitName))
+		print.PrintInfo(fmt.Sprintf("Logs: journalctl --user -u %s -f", res.UnitName))
 	} else {
-		ui.PrintInfo(fmt.Sprintf("Status: sudo systemctl status %s", res.UnitName))
-		ui.PrintInfo(fmt.Sprintf("Logs: sudo journalctl -u %s -f", res.UnitName))
+		print.PrintInfo(fmt.Sprintf("Status: sudo systemctl status %s", res.UnitName))
+		print.PrintInfo(fmt.Sprintf("Logs: sudo journalctl -u %s -f", res.UnitName))
 	}
-	ui.PrintInfo("Process berjalan di background.")
+	print.PrintInfo("Process berjalan di background.")
 	_ = res // output disimpan untuk troubleshooting bila diperlukan
 	return nil
 }

--- a/internal/app/dbscan/helpers/display.go
+++ b/internal/app/dbscan/helpers/display.go
@@ -10,26 +10,28 @@ import (
 
 	dbscanmodel "sfDBTools/internal/app/dbscan/model"
 	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/table"
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 )
 
 // DisplayScanResult menampilkan hasil scanning ke UI
 func DisplayScanResult(result *dbscanmodel.ScanResult) {
-	ui.PrintHeader("HASIL SCANNING")
+	print.PrintHeader("HASIL SCANNING")
 
 	data := [][]string{
 		{"Total Database", fmt.Sprintf("%d", result.TotalDatabases)},
-		{"Berhasil", ui.ColorText(fmt.Sprintf("%d", result.SuccessCount), consts.UIColorGreen)},
-		{"Gagal", ui.ColorText(fmt.Sprintf("%d", result.FailedCount), consts.UIColorRed)},
+		{"Berhasil", text.ColorText(fmt.Sprintf("%d", result.SuccessCount), consts.UIColorGreen)},
+		{"Gagal", text.ColorText(fmt.Sprintf("%d", result.FailedCount), consts.UIColorRed)},
 		{"Durasi", result.Duration},
 	}
 
 	headers := []string{"Metrik", "Nilai"}
-	ui.FormatTable(headers, data)
+	table.Render(headers, data)
 
 	if len(result.Errors) > 0 {
-		ui.PrintWarning(fmt.Sprintf("Terdapat %d error saat menyimpan ke database:", len(result.Errors)))
+		print.PrintWarn(fmt.Sprintf("Terdapat %d error saat menyimpan ke database:", len(result.Errors)))
 		for _, errMsg := range result.Errors {
 			fmt.Printf("  • %s\n", errMsg)
 		}
@@ -38,15 +40,15 @@ func DisplayScanResult(result *dbscanmodel.ScanResult) {
 
 // DisplayDetailResults menampilkan detail hasil scanning ke UI
 func DisplayDetailResults(detailsMap map[string]dbscanmodel.DatabaseDetailInfo) {
-	ui.PrintHeader("DETAIL HASIL SCANNING")
+	print.PrintHeader("DETAIL HASIL SCANNING")
 
 	headers := []string{"Database", "Size", "Tables", "Procedures", "Functions", "Views", "Grants", "Status"}
 	var rows [][]string
 
 	for _, detail := range detailsMap {
-		status := ui.ColorText("✓ OK", consts.UIColorGreen)
+		status := text.ColorText("✓ OK", consts.UIColorGreen)
 		if detail.Error != "" {
-			status = ui.ColorText("✗ Error", consts.UIColorRed)
+			status = text.ColorText("✗ Error", consts.UIColorRed)
 		}
 
 		rows = append(rows, []string{
@@ -61,7 +63,7 @@ func DisplayDetailResults(detailsMap map[string]dbscanmodel.DatabaseDetailInfo) 
 		})
 	}
 
-	ui.FormatTable(headers, rows)
+	table.Render(headers, rows)
 }
 
 // LogScanResult menulis hasil scanning ke logger (untuk background mode)

--- a/internal/app/dbscan/service.go
+++ b/internal/app/dbscan/service.go
@@ -14,12 +14,12 @@ import (
 	dbscanmodel "sfDBTools/internal/app/dbscan/model"
 	appconfig "sfDBTools/internal/services/config"
 	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/database"
 	"sfDBTools/pkg/errorlog"
 	"sfDBTools/pkg/runtimecfg"
 	"sfDBTools/pkg/servicehelper"
-	"sfDBTools/pkg/ui"
 )
 
 // Error definitions
@@ -87,7 +87,7 @@ func (s *Service) ExecuteScan(config dbscanmodel.ScanEntryConfig) error {
 
 	// Print success message jika ada
 	if config.SuccessMsg != "" {
-		ui.PrintSuccess(config.SuccessMsg)
+		print.PrintSuccess(config.SuccessMsg)
 	}
 
 	return nil
@@ -116,7 +116,7 @@ func (s *Service) executeScanWithClients(
 	isBackground bool,
 ) (*dbscanmodel.ScanResult, map[string]dbscanmodel.DatabaseDetailInfo, error) {
 	if !isBackground {
-		ui.PrintSubHeader("Memulai Proses Scanning Database")
+		print.PrintSubHeader("Memulai Proses Scanning Database")
 	}
 
 	// Ambil server info

--- a/internal/app/dbscan/setup.go
+++ b/internal/app/dbscan/setup.go
@@ -12,12 +12,12 @@ import (
 	"sfDBTools/internal/app/dbscan/helpers"
 	dbscanmodel "sfDBTools/internal/app/dbscan/model"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/database"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper"
 	profilehelper "sfDBTools/pkg/helper/profile"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
@@ -86,7 +86,7 @@ func (s *Service) setupScanConnections(ctx context.Context, headerTitle string, 
 // Meload config, connect ke source, dan filter database.
 func (s *Service) prepareScanSession(ctx context.Context, headerTitle string, showOptions bool) (*database.Client, []string, error) {
 	if headerTitle != "" {
-		ui.Headers(headerTitle)
+		print.PrintAppHeader(headerTitle)
 		s.Log.Infof("=== %s ===", headerTitle)
 	}
 

--- a/internal/app/profile/command.go
+++ b/internal/app/profile/command.go
@@ -8,11 +8,12 @@ package profile
 import (
 	appdeps "sfDBTools/internal/cli/deps"
 	"sfDBTools/internal/cli/parsing"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
+
+	profilemodel "sfDBTools/internal/app/profile/model"
 
 	"github.com/spf13/cobra"
-	profilemodel "sfDBTools/internal/app/profile/model"
 )
 
 var profileExecutionConfigs = map[string]profilemodel.ProfileEntryConfig{
@@ -95,7 +96,7 @@ func executeProfileWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, co
 
 	// Tampilkan header jika ada
 	if config.HeaderTitle != "" {
-		ui.Headers(config.HeaderTitle)
+		print.PrintAppHeader(config.HeaderTitle)
 	}
 
 	// Execute profile command
@@ -105,7 +106,7 @@ func executeProfileWithConfig(cmd *cobra.Command, deps *appdeps.Dependencies, co
 
 	// Print success message jika ada
 	if config.SuccessMsg != "" {
-		ui.PrintSuccess(config.SuccessMsg)
+		print.PrintSuccess(config.SuccessMsg)
 		logger.Info(config.SuccessMsg)
 	}
 

--- a/internal/app/profile/display/displayer.go
+++ b/internal/app/profile/display/displayer.go
@@ -11,10 +11,11 @@ import (
 
 	profilemodel "sfDBTools/internal/app/profile/model"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
+	"sfDBTools/internal/ui/table"
 	"sfDBTools/pkg/consts"
 	profilehelper "sfDBTools/pkg/helper/profile"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 
 	"github.com/AlecAivazis/survey/v2"
 )
@@ -33,12 +34,12 @@ func (d *Displayer) DisplayProfileDetails() {
 			if title == "" && d.ProfileInfo != nil {
 				title = d.ProfileInfo.Name
 			}
-			ui.PrintSubHeader(consts.ProfileDisplayShowPrefix + title)
+			print.PrintSubHeader(consts.ProfileDisplayShowPrefix + title)
 			d.printShowDetails()
 			return
 		}
 		if d.ProfileInfo != nil {
-			ui.PrintSubHeader(consts.ProfileDisplayShowPrefix + d.ProfileInfo.Name)
+			print.PrintSubHeader(consts.ProfileDisplayShowPrefix + d.ProfileInfo.Name)
 		}
 		d.printCreateSummary()
 		return
@@ -46,14 +47,14 @@ func (d *Displayer) DisplayProfileDetails() {
 
 	if d.OriginalProfileInfo != nil {
 		if d.ProfileInfo != nil {
-			ui.PrintSubHeader(consts.ProfileMsgChangeSummaryPrefix + d.ProfileInfo.Name)
+			print.PrintSubHeader(consts.ProfileMsgChangeSummaryPrefix + d.ProfileInfo.Name)
 		}
 		d.printChangeSummary()
 		return
 	}
 
 	if d.ProfileInfo != nil {
-		ui.PrintSubHeader(consts.ProfileDisplayCreatePrefix + d.ProfileInfo.Name)
+		print.PrintSubHeader(consts.ProfileDisplayCreatePrefix + d.ProfileInfo.Name)
 	}
 	d.printCreateSummary()
 }
@@ -61,7 +62,7 @@ func (d *Displayer) DisplayProfileDetails() {
 func (d *Displayer) printShowDetails() {
 	orig := d.OriginalProfileInfo
 	if orig == nil {
-		ui.PrintInfo(consts.ProfileDisplayNoConfigLoaded)
+		print.PrintInfo(consts.ProfileDisplayNoConfigLoaded)
 		return
 	}
 
@@ -92,7 +93,7 @@ func (d *Displayer) printShowDetails() {
 		rows = append(rows, []string{"13", consts.ProfileLabelSSHPassword, sshPwState})
 	}
 
-	ui.FormatTable([]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderValue}, rows)
+	table.Render([]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderValue}, rows)
 
 	if d.ProfileShow != nil && d.ProfileShow.RevealPassword && d.ProfileShow.Interactive {
 		d.revealPasswordConfirmAndShow(orig)
@@ -101,17 +102,17 @@ func (d *Displayer) printShowDetails() {
 
 func (d *Displayer) revealPasswordConfirmAndShow(orig *domain.ProfileInfo) {
 	if orig.Path == "" {
-		ui.PrintWarning(consts.ProfileDisplayNoFileForVerify)
+		print.PrintWarning(consts.ProfileDisplayNoFileForVerify)
 		return
 	}
 
-	key, err := input.AskPassword(consts.ProfileDisplayVerifyKeyPrompt, survey.Required)
+	key, err := prompt.AskPassword(consts.ProfileDisplayVerifyKeyPrompt, survey.Required)
 	if err != nil {
-		ui.PrintWarning(consts.ProfileDisplayVerifyKeyFailedPrefix + err.Error())
+		print.PrintWarning(consts.ProfileDisplayVerifyKeyFailedPrefix + err.Error())
 		return
 	}
 	if key == "" {
-		ui.PrintWarning(consts.ProfileDisplayNoKeyProvided)
+		print.PrintWarning(consts.ProfileDisplayNoKeyProvided)
 		return
 	}
 
@@ -122,7 +123,7 @@ func (d *Displayer) revealPasswordConfirmAndShow(orig *domain.ProfileInfo) {
 		RequireProfile: true,
 	})
 	if err != nil {
-		ui.PrintWarning(consts.ProfileDisplayInvalidKeyOrCorrupt)
+		print.PrintWarning(consts.ProfileDisplayInvalidKeyOrCorrupt)
 		return
 	}
 
@@ -132,8 +133,8 @@ func (d *Displayer) revealPasswordConfirmAndShow(orig *domain.ProfileInfo) {
 		display = realPw
 	}
 
-	ui.PrintSubHeader(consts.ProfileDisplayRevealedPasswordTitle)
-	ui.FormatTable(
+	print.PrintSubHeader(consts.ProfileDisplayRevealedPasswordTitle)
+	table.Render(
 		[]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderValue},
 		[][]string{{"1", consts.ProfileLabelDBPassword, display}},
 	)
@@ -141,7 +142,7 @@ func (d *Displayer) revealPasswordConfirmAndShow(orig *domain.ProfileInfo) {
 
 func (d *Displayer) printCreateSummary() {
 	if d.ProfileInfo == nil {
-		ui.PrintInfo(consts.ProfileDisplayNoProfileInfo)
+		print.PrintInfo(consts.ProfileDisplayNoProfileInfo)
 		return
 	}
 	rows := [][]string{
@@ -172,13 +173,13 @@ func (d *Displayer) printCreateSummary() {
 		rows = append(rows, []string{"8", consts.ProfileLabelSSHPassword, sshPwState})
 	}
 
-	ui.FormatTable([]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderValue}, rows)
+	table.Render([]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderValue}, rows)
 }
 
 func (d *Displayer) printChangeSummary() {
 	orig := d.OriginalProfileInfo
 	if orig == nil || d.ProfileInfo == nil {
-		ui.PrintInfo(consts.ProfileDisplayNoChangeInfo)
+		print.PrintInfo(consts.ProfileDisplayNoChangeInfo)
 		return
 	}
 
@@ -226,9 +227,9 @@ func (d *Displayer) printChangeSummary() {
 	}
 
 	if len(rows) == 0 {
-		ui.PrintInfo(consts.ProfileDisplayNoChangesDetected)
+		print.PrintInfo(consts.ProfileDisplayNoChangesDetected)
 		return
 	}
 
-	ui.FormatTable([]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderBefore, consts.ProfileDisplayTableHeaderAfter}, rows)
+	table.Render([]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderBefore, consts.ProfileDisplayTableHeaderAfter}, rows)
 }

--- a/internal/app/profile/executor/create.go
+++ b/internal/app/profile/executor/create.go
@@ -2,21 +2,21 @@
 // Deskripsi : Eksekusi pembuatan profile
 // Author : Hadiyatna Muflihun
 // Tanggal : 4 Januari 2026
-// Last Modified : 4 Januari 2026
+// Last Modified : 5 Januari 2026
 
 package executor
 
 import (
 	"fmt"
 
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/runtimecfg"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
 func (e *Executor) CreateProfile() error {
-	ui.Headers(consts.ProfileUIHeaderCreate)
+	print.PrintAppHeader(consts.ProfileUIHeaderCreate)
 	if e.Log != nil {
 		e.Log.Info(consts.ProfileLogCreateStarted)
 	}
@@ -57,7 +57,7 @@ func (e *Executor) CreateProfile() error {
 
 		if e.CheckConfigurationNameUnique != nil {
 			if err := e.CheckConfigurationNameUnique(consts.ProfileModeCreate); err != nil {
-				ui.PrintError(err.Error())
+				print.PrintError(err.Error())
 				return err
 			}
 		}

--- a/internal/app/profile/executor/delete.go
+++ b/internal/app/profile/executor/delete.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
@@ -63,7 +63,7 @@ func (e *Executor) deletePaths(paths []string, logSuccessFmt string, showErrorOn
 				}
 			}
 			if showErrorOnFail {
-				ui.PrintError(fmt.Sprintf(consts.ProfileDeleteFailedFmt, p, err))
+				print.PrintError(fmt.Sprintf(consts.ProfileDeleteFailedFmt, p, err))
 			}
 			continue
 		}
@@ -72,12 +72,12 @@ func (e *Executor) deletePaths(paths []string, logSuccessFmt string, showErrorOn
 			e.Log.Info(fmt.Sprintf(logSuccessFmt, p))
 		}
 		// UI success selalu pakai message yang sama seperti sebelumnya.
-		ui.PrintSuccess(fmt.Sprintf(consts.ProfileDeleteDeletedFmt, p))
+		print.PrintSuccess(fmt.Sprintf(consts.ProfileDeleteDeletedFmt, p))
 	}
 }
 
 func (e *Executor) PromptDeleteProfile() error {
-	ui.Headers(consts.ProfileUIHeaderDelete)
+	print.PrintAppHeader(consts.ProfileUIHeaderDelete)
 	isInteractive := e.isInteractiveMode()
 
 	force := false
@@ -110,7 +110,7 @@ func (e *Executor) PromptDeleteProfile() error {
 		}
 
 		if len(validPaths) == 0 {
-			ui.PrintInfo(consts.ProfileDeleteNoValidProfiles)
+			print.PrintInfo(consts.ProfileDeleteNoValidProfiles)
 			return nil
 		}
 
@@ -119,17 +119,17 @@ func (e *Executor) PromptDeleteProfile() error {
 			return nil
 		}
 
-		ui.PrintWarning(consts.ProfileDeleteWillDeleteHeader)
+		print.PrintWarning(consts.ProfileDeleteWillDeleteHeader)
 		for _, d := range displayNames {
-			ui.PrintWarning(consts.ProfileDeleteListPrefix + d)
+			print.PrintWarning(consts.ProfileDeleteListPrefix + d)
 		}
 
-		ok, err := input.AskYesNo(fmt.Sprintf(consts.ProfileDeleteConfirmCountFmt, len(validPaths)), false)
+		ok, err := prompt.Confirm(fmt.Sprintf(consts.ProfileDeleteConfirmCountFmt, len(validPaths)), false)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
 		if !ok {
-			ui.PrintInfo(consts.ProfileDeleteCancelledByUser)
+			print.PrintInfo(consts.ProfileDeleteCancelledByUser)
 			return nil
 		}
 
@@ -145,11 +145,11 @@ func (e *Executor) PromptDeleteProfile() error {
 
 	filtered := filterProfileConfigFiles(files)
 	if len(filtered) == 0 {
-		ui.PrintInfo(consts.ProfileDeleteNoConfigFiles)
+		print.PrintInfo(consts.ProfileDeleteNoConfigFiles)
 		return nil
 	}
 
-	idxs, err := input.ShowMultiSelect(consts.ProfileDeleteSelectFilesPrompt, filtered)
+	_, idxs, err := prompt.SelectMany(consts.ProfileDeleteSelectFilesPrompt, filtered, nil)
 	if err != nil {
 		return validation.HandleInputError(err)
 	}
@@ -162,17 +162,17 @@ func (e *Executor) PromptDeleteProfile() error {
 	}
 
 	if len(selected) == 0 {
-		ui.PrintInfo(consts.ProfileDeleteNoFilesSelected)
+		print.PrintInfo(consts.ProfileDeleteNoFilesSelected)
 		return nil
 	}
 
 	if !force {
-		ok, err := input.AskYesNo(fmt.Sprintf(consts.ProfileDeleteConfirmFilesCountFmt, len(selected)), false)
+		ok, err := prompt.Confirm(fmt.Sprintf(consts.ProfileDeleteConfirmFilesCountFmt, len(selected)), false)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
 		if !ok {
-			ui.PrintInfo(consts.ProfileDeleteCancelledByUser)
+			print.PrintInfo(consts.ProfileDeleteCancelledByUser)
 			return nil
 		}
 	}

--- a/internal/app/profile/executor/edit.go
+++ b/internal/app/profile/executor/edit.go
@@ -11,15 +11,15 @@ import (
 	"strings"
 
 	"sfDBTools/internal/app/profile/shared"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
 func (e *Executor) EditProfile() error {
-	ui.Headers(consts.ProfileUIHeaderEdit)
+	print.PrintAppHeader(consts.ProfileUIHeaderEdit)
 
 	for {
 		if e.ProfileEdit != nil && e.ProfileEdit.Interactive {
@@ -57,7 +57,7 @@ func (e *Executor) EditProfile() error {
 				return err
 			}
 			if !fsops.PathExists(absPath) {
-				ui.PrintWarning(fmt.Sprintf(consts.ProfileWarnConfigFileNotFoundFmt, absPath))
+				print.PrintWarning(fmt.Sprintf(consts.ProfileWarnConfigFileNotFoundFmt, absPath))
 				return fmt.Errorf(consts.ProfileErrConfigFileNotFoundFmt, absPath)
 			}
 
@@ -70,7 +70,7 @@ func (e *Executor) EditProfile() error {
 			}
 			if e.LoadSnapshotFromPath != nil {
 				if snap, err := e.LoadSnapshotFromPath(absPath); err != nil {
-					ui.PrintWarning(fmt.Sprintf(consts.ProfileWarnLoadFileContentFailedProceedFmt, absPath, err))
+					print.PrintWarning(fmt.Sprintf(consts.ProfileWarnLoadFileContentFailedProceedFmt, absPath, err))
 				} else {
 					e.OriginalProfileInfo = snap
 				}
@@ -112,7 +112,7 @@ func (e *Executor) EditProfile() error {
 
 		if e.CheckConfigurationNameUnique != nil {
 			if err := e.CheckConfigurationNameUnique(consts.ProfileModeEdit); err != nil {
-				ui.PrintError(err.Error())
+				print.PrintError(err.Error())
 				return err
 			}
 		}

--- a/internal/app/profile/executor/retry_helper.go
+++ b/internal/app/profile/executor/retry_helper.go
@@ -7,21 +7,21 @@
 package executor
 
 import (
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
 func (e *Executor) handleConnectionFailedRetry(retryWarningMsg string, cancelInfoMsg string) (bool, error) {
-	retryInput, askErr := input.AskYesNo(consts.ProfilePromptRetryInputConfig, true)
+	retryInput, askErr := prompt.Confirm(consts.ProfilePromptRetryInputConfig, true)
 	if askErr != nil {
 		return false, validation.HandleInputError(askErr)
 	}
 	if retryInput {
-		ui.PrintWarning(retryWarningMsg)
+		print.PrintWarning(retryWarningMsg)
 		return true, nil
 	}
-	ui.PrintInfo(cancelInfoMsg)
+	print.PrintInfo(cancelInfoMsg)
 	return false, validation.ErrUserCancelled
 }

--- a/internal/app/profile/executor/save.go
+++ b/internal/app/profile/executor/save.go
@@ -13,13 +13,13 @@ import (
 	"strings"
 
 	"sfDBTools/internal/app/profile/shared"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/encrypt"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper"
 	profilehelper "sfDBTools/pkg/helper/profile"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
@@ -48,14 +48,14 @@ func (e *Executor) SaveProfile(mode string) error {
 		if !isInteractive {
 			return err
 		}
-		continueAnyway, askErr := input.AskYesNo(consts.ProfileSavePromptContinueDespiteDBFail, false)
+		continueAnyway, askErr := prompt.Confirm(consts.ProfileSavePromptContinueDespiteDBFail, false)
 		if askErr != nil {
 			return validation.HandleInputError(askErr)
 		}
 		if !continueAnyway {
 			return validation.ErrConnectionFailedRetry
 		}
-		ui.PrintWarning(consts.ProfileSaveWarnSavingWithInvalidConn)
+		print.PrintWarning(consts.ProfileSaveWarnSavingWithInvalidConn)
 	} else {
 		c.Close()
 		if e.Log != nil {
@@ -110,10 +110,10 @@ func (e *Executor) SaveProfile(mode string) error {
 		}
 
 		if err := os.Remove(oldFilePath); err != nil {
-			ui.PrintWarning(fmt.Sprintf(consts.ProfileWarnSavedButDeleteOldFailedFmt, newFileName, oldFilePath, err))
+			print.PrintWarning(fmt.Sprintf(consts.ProfileWarnSavedButDeleteOldFailedFmt, newFileName, oldFilePath, err))
 		}
-		ui.PrintSuccess(fmt.Sprintf(consts.ProfileSuccessSavedRenamedFmt, newFileName, shared.BuildProfileFileName(e.OriginalProfileName)))
-		ui.PrintInfo(consts.ProfileMsgConfigSavedAtPrefix + newFilePath)
+		print.PrintSuccess(fmt.Sprintf(consts.ProfileSuccessSavedRenamedFmt, newFileName, shared.BuildProfileFileName(e.OriginalProfileName)))
+		print.PrintInfo(consts.ProfileMsgConfigSavedAtPrefix + newFilePath)
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func (e *Executor) SaveProfile(mode string) error {
 		return fmt.Errorf(consts.ProfileErrWriteConfigFailedFmt, err)
 	}
 
-	ui.PrintSuccess(fmt.Sprintf(consts.ProfileSuccessSavedSafelyFmt, newFileName))
-	ui.PrintInfo(consts.ProfileMsgConfigSavedAtPrefix + newFilePath)
+	print.PrintSuccess(fmt.Sprintf(consts.ProfileSuccessSavedSafelyFmt, newFileName))
+	print.PrintInfo(consts.ProfileMsgConfigSavedAtPrefix + newFilePath)
 	return nil
 }

--- a/internal/app/profile/executor/show.go
+++ b/internal/app/profile/executor/show.go
@@ -8,17 +8,18 @@ package executor
 import (
 	"fmt"
 	profilemodel "sfDBTools/internal/app/profile/model"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/table"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper"
 	profilehelper "sfDBTools/pkg/helper/profile"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 	"strings"
 )
 
 func (e *Executor) ShowProfile() error {
-	ui.Headers(consts.ProfileUIHeaderShow)
+	print.PrintAppHeader(consts.ProfileUIHeaderShow)
 	isInteractive := e.isInteractiveMode()
 
 	if !isInteractive {
@@ -86,7 +87,7 @@ func (e *Executor) ShowProfile() error {
 	}
 
 	if c, err := profilehelper.ConnectWithProfile(e.ProfileInfo, consts.DefaultInitialDatabase); err != nil {
-		ui.PrintWarning(consts.ProfileWarnDBConnectFailedPrefix + err.Error())
+		print.PrintWarning(consts.ProfileWarnDBConnectFailedPrefix + err.Error())
 	} else {
 		c.Close()
 	}
@@ -115,8 +116,8 @@ func (e *Executor) ShowProfile() error {
 		if strings.TrimSpace(info.DBInfo.Password) != "" {
 			display = info.DBInfo.Password
 		}
-		ui.PrintSubHeader(consts.ProfileDisplayRevealedPasswordTitle)
-		ui.FormatTable(
+		print.PrintSubHeader(consts.ProfileDisplayRevealedPasswordTitle)
+		table.Render(
 			[]string{consts.ProfileDisplayTableHeaderNo, consts.ProfileDisplayTableHeaderField, consts.ProfileDisplayTableHeaderValue},
 			[][]string{{"1", consts.ProfileLabelDBPassword, display}},
 		)

--- a/internal/app/profile/profile_validation.go
+++ b/internal/app/profile/profile_validation.go
@@ -12,15 +12,16 @@ import (
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
 	"sfDBTools/pkg/runtimecfg"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 	"strings"
 
+	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
+
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/mattn/go-isatty"
-	"sfDBTools/internal/domain"
 )
 
 // CheckConfigurationNameUnique memvalidasi apakah nama konfigurasi unik.
@@ -117,8 +118,8 @@ func ValidateDBInfo(db *domain.DBInfo) error {
 				validation.ErrNonInteractive,
 			)
 		}
-		ui.PrintWarning(consts.ProfileWarnDBPasswordPrompting)
-		pw, err := input.AskPassword(fmt.Sprintf(consts.ProfilePromptDBPasswordForUserFmt, db.User), survey.Required)
+		print.PrintWarning(consts.ProfileWarnDBPasswordPrompting)
+		pw, err := prompt.AskPassword(fmt.Sprintf(consts.ProfilePromptDBPasswordForUserFmt, db.User), survey.Required)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}

--- a/internal/app/profile/wizard/create_flow.go
+++ b/internal/app/profile/wizard/create_flow.go
@@ -10,9 +10,9 @@ import (
 
 	"sfDBTools/internal/app/profile/shared"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 )
 
 func (r *Runner) runCreateFlow(mode string) error {
@@ -29,13 +29,13 @@ func (r *Runner) runCreateFlow(mode string) error {
 		r.ProfileInfo.Name = helper.TrimProfileSuffix(r.ProfileInfo.Name)
 		if r.CheckConfigurationNameUnique != nil {
 			if err := r.CheckConfigurationNameUnique(mode); err != nil {
-				ui.PrintError(err.Error())
+				print.PrintError(err.Error())
 				// Jika nama dari flag/env ternyata bentrok, minta user input nama baru.
 				if err2 := r.promptDBConfigName(mode); err2 != nil {
 					return err2
 				}
 			} else {
-				ui.PrintInfo(consts.ProfileMsgConfigWillBeSavedAsPrefix + shared.BuildProfileFileName(r.ProfileInfo.Name))
+				print.PrintInfo(consts.ProfileMsgConfigWillBeSavedAsPrefix + shared.BuildProfileFileName(r.ProfileInfo.Name))
 			}
 		}
 	}

--- a/internal/app/profile/wizard/edit_fields.go
+++ b/internal/app/profile/wizard/edit_fields.go
@@ -7,9 +7,9 @@
 package wizard
 
 import (
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -31,12 +31,12 @@ func (r *Runner) promptEditSelectedFields() error {
 		consts.ProfileLabelSSHLocalPort,
 	}
 
-	idxs, err := input.ShowMultiSelect(consts.ProfilePromptSelectFieldsToChange, fields)
+	_, idxs, err := prompt.SelectMany(consts.ProfilePromptSelectFieldsToChange, fields, nil)
 	if err != nil {
 		return validation.HandleInputError(err)
 	}
 	if len(idxs) == 0 {
-		ui.PrintWarning(consts.ProfileMsgNoFieldsSelected)
+		print.PrintWarning(consts.ProfileMsgNoFieldsSelected)
 		return validation.ErrUserCancelled
 	}
 
@@ -54,7 +54,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileLabelDBHost] {
-		v, err := input.AskString(consts.ProfileLabelDBHost, r.ProfileInfo.DBInfo.Host, survey.Required)
+		v, err := prompt.AskText(consts.ProfileLabelDBHost, prompt.WithDefault(r.ProfileInfo.DBInfo.Host), prompt.WithValidator(survey.Required))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -62,7 +62,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileLabelDBPort] {
-		v, err := input.AskInt(consts.ProfileLabelDBPort, r.ProfileInfo.DBInfo.Port, survey.Required)
+		v, err := prompt.AskInt(consts.ProfileLabelDBPort, r.ProfileInfo.DBInfo.Port, survey.Required)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -70,7 +70,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileLabelDBUser] {
-		v, err := input.AskString(consts.ProfileLabelDBUser, r.ProfileInfo.DBInfo.User, survey.Required)
+		v, err := prompt.AskText(consts.ProfileLabelDBUser, prompt.WithDefault(r.ProfileInfo.DBInfo.User), prompt.WithValidator(survey.Required))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -82,8 +82,8 @@ func (r *Runner) promptEditSelectedFields() error {
 		if r.ProfileInfo != nil {
 			existing = r.ProfileInfo.DBInfo.Password
 		}
-		ui.PrintInfo(consts.ProfileTipKeepCurrentDBPassword)
-		pw, err := input.AskPassword(consts.ProfileLabelDBPassword, nil)
+		print.PrintInfo(consts.ProfileTipKeepCurrentDBPassword)
+		pw, err := prompt.AskPassword(consts.ProfileLabelDBPassword, nil)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -95,7 +95,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileFieldSSHTunnelToggle] {
-		enable, err := input.AskYesNo(consts.ProfilePromptUseSSHTunnel, r.ProfileInfo.SSHTunnel.Enabled)
+		enable, err := prompt.Confirm(consts.ProfilePromptUseSSHTunnel, r.ProfileInfo.SSHTunnel.Enabled)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -108,7 +108,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileLabelSSHHost] {
-		v, err := input.AskString(consts.ProfilePromptSSHHost, r.ProfileInfo.SSHTunnel.Host, sshRequired)
+		v, err := prompt.AskText(consts.ProfilePromptSSHHost, prompt.WithDefault(r.ProfileInfo.SSHTunnel.Host), prompt.WithValidator(sshRequired))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -120,7 +120,7 @@ func (r *Runner) promptEditSelectedFields() error {
 		if def == 0 {
 			def = 22
 		}
-		v, err := input.AskInt(consts.ProfileLabelSSHPort, def, sshRequired)
+		v, err := prompt.AskInt(consts.ProfileLabelSSHPort, def, sshRequired)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -128,7 +128,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileLabelSSHUser] {
-		v, err := input.AskString(consts.ProfilePromptSSHUser, r.ProfileInfo.SSHTunnel.User, nil)
+		v, err := prompt.AskText(consts.ProfilePromptSSHUser, prompt.WithDefault(r.ProfileInfo.SSHTunnel.User))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -140,8 +140,8 @@ func (r *Runner) promptEditSelectedFields() error {
 		if r.ProfileInfo != nil {
 			existing = r.ProfileInfo.SSHTunnel.Password
 		}
-		ui.PrintInfo(consts.ProfileTipKeepCurrentSSHPassword)
-		pw, err := input.AskPassword(consts.ProfilePromptSSHPasswordOptional, nil)
+		print.PrintInfo(consts.ProfileTipKeepCurrentSSHPassword)
+		pw, err := prompt.AskPassword(consts.ProfilePromptSSHPasswordOptional, nil)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -153,7 +153,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileLabelSSHIdentityFile] {
-		v, err := input.AskString(consts.ProfilePromptSSHIdentityFileOptional, r.ProfileInfo.SSHTunnel.IdentityFile, nil)
+		v, err := prompt.AskText(consts.ProfilePromptSSHIdentityFileOptional, prompt.WithDefault(r.ProfileInfo.SSHTunnel.IdentityFile))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -161,7 +161,7 @@ func (r *Runner) promptEditSelectedFields() error {
 	}
 
 	if selected[consts.ProfileLabelSSHLocalPort] {
-		v, err := input.AskInt(consts.ProfilePromptSSHLocalPort, r.ProfileInfo.SSHTunnel.LocalPort, nil)
+		v, err := prompt.AskInt(consts.ProfilePromptSSHLocalPort, r.ProfileInfo.SSHTunnel.LocalPort, nil)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}

--- a/internal/app/profile/wizard/edit_flow.go
+++ b/internal/app/profile/wizard/edit_flow.go
@@ -12,11 +12,11 @@ import (
 	profilemodel "sfDBTools/internal/app/profile/model"
 	"sfDBTools/internal/app/profile/shared"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
@@ -83,7 +83,7 @@ func (r *Runner) runEditFlow() error {
 		}
 		r.ProfileShow = prevShow
 
-		action, err := input.SelectSingleFromList([]string{consts.ProfileActionEditData, consts.ProfileActionCancel}, consts.ProfilePromptAction)
+		action, _, err := prompt.SelectOne(consts.ProfilePromptAction, []string{consts.ProfileActionEditData, consts.ProfileActionCancel}, -1)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -101,6 +101,6 @@ func (r *Runner) runEditFlow() error {
 		return err
 	}
 
-	ui.PrintSubHeader(consts.ProfileMsgChangeSummaryPrefix + r.ProfileInfo.Name)
+	print.PrintSubHeader(consts.ProfileMsgChangeSummaryPrefix + r.ProfileInfo.Name)
 	return nil
 }

--- a/internal/app/profile/wizard/prompts.go
+++ b/internal/app/profile/wizard/prompts.go
@@ -12,24 +12,24 @@ import (
 	"strings"
 
 	"sfDBTools/internal/app/profile/shared"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 
 	"github.com/AlecAivazis/survey/v2"
 )
 
 func (r *Runner) promptDBConfigName(mode string) error {
-	ui.PrintSubHeader(consts.ProfileWizardSubHeaderConfigName)
+	print.PrintSubHeader(consts.ProfileWizardSubHeaderConfigName)
 
 	for {
-		nameValidator := input.ComposeValidators(survey.Required, input.ValidateFilename)
+		nameValidator := prompt.ComposeValidators(survey.Required, prompt.ValidateFilename)
 		def := strings.TrimSpace(r.ProfileInfo.Name)
 		if def == "" {
 			def = consts.ProfileWizardDefaultConfigName
 		}
-		configName, err := input.AskString(consts.ProfileWizardLabelConfigName, def, nameValidator)
+		configName, err := prompt.AskText(consts.ProfileWizardLabelConfigName, prompt.WithDefault(def), prompt.WithValidator(nameValidator))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -37,7 +37,7 @@ func (r *Runner) promptDBConfigName(mode string) error {
 		r.ProfileInfo.Name = strings.TrimSpace(configName)
 		if r.CheckConfigurationNameUnique != nil {
 			if err = r.CheckConfigurationNameUnique(mode); err != nil {
-				ui.PrintError(err.Error())
+				print.PrintError(err.Error())
 				continue
 			}
 		}
@@ -45,16 +45,16 @@ func (r *Runner) promptDBConfigName(mode string) error {
 	}
 
 	r.ProfileInfo.Name = strings.TrimSpace(r.ProfileInfo.Name)
-	ui.PrintInfo(consts.ProfileMsgConfigWillBeSavedAsPrefix + shared.BuildProfileFileName(r.ProfileInfo.Name))
+	print.PrintInfo(consts.ProfileMsgConfigWillBeSavedAsPrefix + shared.BuildProfileFileName(r.ProfileInfo.Name))
 	return nil
 }
 
 func (r *Runner) promptProfileInfo() error {
-	ui.PrintSubHeader(consts.ProfileWizardSubHeaderProfileDetails)
+	print.PrintSubHeader(consts.ProfileWizardSubHeaderProfileDetails)
 
 	// Host
 	if strings.TrimSpace(r.ProfileInfo.DBInfo.Host) == "" {
-		v, err := input.AskString(consts.ProfileLabelDBHost, "localhost", survey.Required)
+		v, err := prompt.AskText(consts.ProfileLabelDBHost, prompt.WithDefault("localhost"), prompt.WithValidator(survey.Required))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -63,7 +63,7 @@ func (r *Runner) promptProfileInfo() error {
 
 	// Port
 	if r.ProfileInfo.DBInfo.Port == 0 {
-		v, err := input.AskInt(consts.ProfileLabelDBPort, 3306, survey.Required)
+		v, err := prompt.AskInt(consts.ProfileLabelDBPort, 3306, survey.Required)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -72,7 +72,7 @@ func (r *Runner) promptProfileInfo() error {
 
 	// User
 	if strings.TrimSpace(r.ProfileInfo.DBInfo.User) == "" {
-		v, err := input.AskString(consts.ProfileLabelDBUser, "root", survey.Required)
+		v, err := prompt.AskText(consts.ProfileLabelDBUser, prompt.WithDefault("root"), prompt.WithValidator(survey.Required))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -87,12 +87,12 @@ func (r *Runner) promptProfileInfo() error {
 			r.ProfileInfo.DBInfo.Password = envPassword
 		} else {
 			if !isEditFlow {
-				ui.PrintWarning(fmt.Sprintf(consts.ProfileWarnEnvVarMissingOrEmptyFmt, consts.ENV_TARGET_DB_PASSWORD, consts.ENV_TARGET_DB_PASSWORD))
+				print.PrintWarning(fmt.Sprintf(consts.ProfileWarnEnvVarMissingOrEmptyFmt, consts.ENV_TARGET_DB_PASSWORD, consts.ENV_TARGET_DB_PASSWORD))
 			}
 			if isEditFlow {
-				ui.PrintInfo(consts.ProfileTipKeepCurrentDBPasswordUpdate)
+				print.PrintInfo(consts.ProfileTipKeepCurrentDBPasswordUpdate)
 			}
-			pw, err := input.AskPassword(consts.ProfileLabelDBPassword, survey.Required)
+			pw, err := prompt.AskPassword(consts.ProfileLabelDBPassword, survey.Required)
 			if err != nil {
 				return validation.HandleInputError(err)
 			}
@@ -110,7 +110,7 @@ func (r *Runner) promptProfileInfo() error {
 func (r *Runner) promptSSHTunnelDetailsIfEnabledOrAsk() error {
 	enabled := r.ProfileInfo.SSHTunnel.Enabled
 	if !enabled {
-		v, err := input.AskYesNo(consts.ProfilePromptUseSSHTunnel, false)
+		v, err := prompt.Confirm(consts.ProfilePromptUseSSHTunnel, false)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -134,7 +134,7 @@ func (r *Runner) promptSSHTunnelDetailsIfEnabled() error {
 	ssh := &r.ProfileInfo.SSHTunnel
 	// Host wajib
 	if strings.TrimSpace(ssh.Host) == "" {
-		v, err := input.AskString(consts.ProfilePromptSSHHost, "", survey.Required)
+		v, err := prompt.AskText(consts.ProfilePromptSSHHost, prompt.WithDefault(""), prompt.WithValidator(survey.Required))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -142,7 +142,7 @@ func (r *Runner) promptSSHTunnelDetailsIfEnabled() error {
 	}
 	// Port default 22
 	if ssh.Port == 0 {
-		v, err := input.AskInt(consts.ProfileLabelSSHPort, 22, survey.Required)
+		v, err := prompt.AskInt(consts.ProfileLabelSSHPort, 22, survey.Required)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -150,7 +150,7 @@ func (r *Runner) promptSSHTunnelDetailsIfEnabled() error {
 	}
 	// User optional
 	if strings.TrimSpace(ssh.User) == "" {
-		v, err := input.AskString(consts.ProfilePromptSSHUser, "", nil)
+		v, err := prompt.AskText(consts.ProfilePromptSSHUser, prompt.WithDefault(""))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -159,8 +159,8 @@ func (r *Runner) promptSSHTunnelDetailsIfEnabled() error {
 
 	// Password opsional
 	if strings.TrimSpace(ssh.Password) == "" {
-		ui.PrintInfo(consts.ProfileTipSSHPasswordOptional)
-		pw, err := input.AskPassword(consts.ProfilePromptSSHPasswordOptional, nil)
+		print.PrintInfo(consts.ProfileTipSSHPasswordOptional)
+		pw, err := prompt.AskPassword(consts.ProfilePromptSSHPasswordOptional, nil)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -171,7 +171,7 @@ func (r *Runner) promptSSHTunnelDetailsIfEnabled() error {
 
 	// Identity file opsional
 	if strings.TrimSpace(ssh.IdentityFile) == "" {
-		v, err := input.AskString(consts.ProfilePromptSSHIdentityFileOptional, "", nil)
+		v, err := prompt.AskText(consts.ProfilePromptSSHIdentityFileOptional, prompt.WithDefault(""))
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -180,7 +180,7 @@ func (r *Runner) promptSSHTunnelDetailsIfEnabled() error {
 
 	// Local port opsional
 	if ssh.LocalPort == 0 {
-		v, err := input.AskInt(consts.ProfilePromptSSHLocalPort, 0, nil)
+		v, err := prompt.AskInt(consts.ProfilePromptSSHLocalPort, 0, nil)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}

--- a/internal/app/profile/wizard/runner.go
+++ b/internal/app/profile/wizard/runner.go
@@ -10,10 +10,10 @@ import (
 
 	profilemodel "sfDBTools/internal/app/profile/model"
 	"sfDBTools/internal/domain"
-	"sfDBTools/internal/services/log"
+	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
@@ -58,7 +58,7 @@ func (r *Runner) Run(mode string) error {
 			r.DisplayProfileDetails()
 		}
 
-		confirmSave, err := input.AskYesNo(consts.ProfilePromptConfirmSave, true)
+		confirmSave, err := prompt.Confirm(consts.ProfilePromptConfirmSave, true)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
@@ -66,18 +66,18 @@ func (r *Runner) Run(mode string) error {
 			break
 		}
 
-		confirmRetry, err := input.AskYesNo(consts.ProfilePromptConfirmRetry, false)
+		confirmRetry, err := prompt.Confirm(consts.ProfilePromptConfirmRetry, false)
 		if err != nil {
 			return validation.HandleInputError(err)
 		}
 		if confirmRetry {
-			ui.PrintWarning(consts.ProfileWizardMsgRestart)
+			print.PrintWarning(consts.ProfileWizardMsgRestart)
 			continue
 		}
 		return validation.ErrUserCancelled
 	}
 
-	ui.PrintSuccess(consts.ProfileWizardMsgConfirmAccepted)
+	print.PrintSuccess(consts.ProfileWizardMsgConfirmAccepted)
 
 	if r.ResolveProfileEncryptionKey == nil {
 		return fmt.Errorf(consts.ProfileErrResolveEncryptionKeyUnavailable)

--- a/internal/app/restore/command_helpers.go
+++ b/internal/app/restore/command_helpers.go
@@ -10,12 +10,13 @@ import (
 	"os"
 	"os/signal"
 	appdeps "sfDBTools/internal/cli/deps"
-	"sfDBTools/internal/services/log"
-	"sfDBTools/pkg/ui"
+	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
 	"syscall"
 
-	"github.com/spf13/cobra"
 	restoremodel "sfDBTools/internal/app/restore/model"
+
+	"github.com/spf13/cobra"
 )
 
 type restoreSetupFunc func(ctx context.Context) error
@@ -132,7 +133,7 @@ func executeRestoreCommand(
 
 	show(result)
 
-	ui.PrintSuccess(successMsg)
+	print.PrintSuccess(successMsg)
 	logger.Info(successMsg)
 	return nil
 }

--- a/internal/app/restore/companion_helpers.go
+++ b/internal/app/restore/companion_helpers.go
@@ -2,7 +2,7 @@
 // Deskripsi : Helper functions untuk companion database detection
 // Author : Hadiyatna Muflihun
 // Tanggal : 19 Desember 2025
-// Last Modified : 30 Desember 2025
+// Last Modified : 5 Januari 2026
 
 package restore
 
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -56,7 +56,7 @@ func (s *Service) DetectOrSelectCompanionFile() error {
 	s.Log.Debugf("Auto-detect companion gagal: %v", err)
 
 	// Not found, ask user
-	ui.PrintWarning("⚠️  Companion file tidak ditemukan secara otomatis")
+	print.PrintWarning("⚠️  Companion file tidak ditemukan secara otomatis")
 	if opts.Force {
 		err := fmt.Errorf("dmart file (_dmart) tidak ditemukan secara otomatis dan mode non-interaktif (--force) aktif; gunakan --dmart-file untuk set file dmart, atau set --dmart-include=false, atau gunakan --continue-on-error untuk skip dmart")
 		return s.stopOrSkipCompanionNonInteractive(
@@ -79,7 +79,7 @@ func (s *Service) useCompanionFileFromFlagOrDecide() (bool, error) {
 	fi, err := os.Stat(flagPath)
 	if err != nil {
 		s.Log.Warnf("Companion file dari flag tidak ditemukan: %s", flagPath)
-		ui.PrintWarning(fmt.Sprintf("⚠️  Companion file tidak ditemukan: %s", flagPath))
+		print.PrintWarning(fmt.Sprintf("⚠️  Companion file tidak ditemukan: %s", flagPath))
 		if opts.Force {
 			return true, s.stopOrSkipCompanionNonInteractive(
 				fmt.Errorf("companion file (_dmart) tidak ditemukan: %s", flagPath),
@@ -93,7 +93,7 @@ func (s *Service) useCompanionFileFromFlagOrDecide() (bool, error) {
 
 	if fi.IsDir() {
 		s.Log.Warnf("Companion file dari flag adalah direktori (tidak valid): %s", flagPath)
-		ui.PrintWarning(fmt.Sprintf("⚠️  Companion file tidak valid (path adalah direktori): %s", flagPath))
+		print.PrintWarning(fmt.Sprintf("⚠️  Companion file tidak valid (path adalah direktori): %s", flagPath))
 		if opts.Force {
 			return true, s.stopOrSkipCompanionNonInteractive(
 				fmt.Errorf("companion file (_dmart) tidak valid (path adalah direktori): %s", flagPath),
@@ -108,7 +108,7 @@ func (s *Service) useCompanionFileFromFlagOrDecide() (bool, error) {
 	validExtensions := helper.ValidBackupFileExtensionsForSelection()
 	if !isValidBackupFileExtension(flagPath, validExtensions) {
 		s.Log.Warnf("Companion file dari flag tidak valid (ekstensi): %s", flagPath)
-		ui.PrintWarning(fmt.Sprintf("⚠️  Companion file tidak valid (ekstensi tidak didukung): %s", flagPath))
+		print.PrintWarning(fmt.Sprintf("⚠️  Companion file tidak valid (ekstensi tidak didukung): %s", flagPath))
 		if opts.Force {
 			return true, s.stopOrSkipCompanionNonInteractive(
 				fmt.Errorf("companion file (_dmart) tidak valid (ekstensi tidak didukung): %s", flagPath),
@@ -148,7 +148,7 @@ func (s *Service) stopOrSkipCompanionNonInteractive(err error, warnLog string, w
 
 func (s *Service) skipCompanionRestore(warnLog string, warnUI string) {
 	s.Log.Warn(warnLog)
-	ui.PrintWarning(warnUI)
+	print.PrintWarning(warnUI)
 	s.RestorePrimaryOpts.IncludeDmart = false
 	s.RestorePrimaryOpts.CompanionFile = ""
 }

--- a/internal/app/restore/companion_interactive.go
+++ b/internal/app/restore/companion_interactive.go
@@ -2,16 +2,16 @@
 // Deskripsi : Helper interaktif untuk pemilihan companion (_dmart) file
 // Author : Hadiyatna Muflihun
 // Tanggal : 30 Desember 2025
-// Last Modified : 30 Desember 2025
+// Last Modified : 5 Januari 2026
 
 package restore
 
 import (
 	"fmt"
 	"path/filepath"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -26,7 +26,7 @@ func (s *Service) useOrSelectDetectedCompanionInteractive(detectedPath string) e
 		"📁 [ Browse / pilih dmart file lain ]",
 		"⏭️  [ Skip restore companion database (_dmart) ]",
 	}
-	selected, err := input.SelectSingleFromList(options, "Companion (dmart) file ditemukan. Gunakan file ini atau pilih yang lain?")
+	selected, _, err := prompt.SelectOne("Companion (dmart) file ditemukan. Gunakan file ini atau pilih yang lain?", options, 0)
 	if err == nil && selected == options[0] {
 		s.RestorePrimaryOpts.CompanionFile = detectedPath
 		s.Log.Infof("Companion file dipakai (auto-detect): %s", filepath.Base(detectedPath))
@@ -36,7 +36,7 @@ func (s *Service) useOrSelectDetectedCompanionInteractive(detectedPath string) e
 		s.RestorePrimaryOpts.CompanionFile = ""
 		s.RestorePrimaryOpts.IncludeDmart = false
 		s.Log.Info("Companion database tidak akan di-restore (user memilih skip)")
-		ui.PrintWarning("⚠️  Skip restore companion database (_dmart)")
+		print.PrintWarning("⚠️  Skip restore companion database (_dmart)")
 		return nil
 	}
 
@@ -49,14 +49,14 @@ func (s *Service) useOrSelectDetectedCompanionInteractive(detectedPath string) e
 }
 
 func (s *Service) selectCompanionFileInteractive() error {
-	confirm, err := input.PromptConfirm("Apakah Anda ingin memilih file companion database (_dmart) secara manual?")
+	confirm, err := prompt.PromptConfirm("Apakah Anda ingin memilih file companion database (_dmart) secara manual?")
 	if err != nil {
 		return fmt.Errorf("gagal mendapatkan konfirmasi: %w", err)
 	}
 
 	if !confirm {
 		s.Log.Info("User memilih untuk skip restore companion database")
-		ui.PrintWarning("⚠️  Skip restore companion database")
+		print.PrintWarning("⚠️  Skip restore companion database")
 		s.RestorePrimaryOpts.IncludeDmart = false
 		return nil
 	}
@@ -81,11 +81,9 @@ func (s *Service) browseCompanionFileInteractive() (string, error) {
 		return "", fmt.Errorf("tidak ada file backup ditemukan di direktori: %s", dir)
 	}
 
-	choice, err := input.ShowMenu("Pilih file companion database:", files)
+	selected, _, err := prompt.SelectOne("Pilih file companion database:", files, 0)
 	if err != nil {
 		return "", fmt.Errorf("gagal memilih file: %w", err)
 	}
-
-	selected := strings.TrimSpace(files[choice-1])
-	return filepath.Join(dir, selected), nil
+	return filepath.Join(dir, strings.TrimSpace(selected)), nil
 }

--- a/internal/app/restore/display/display.go
+++ b/internal/app/restore/display/display.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"path/filepath"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 )
 
 // ShowRestoreSingleResult menampilkan hasil restore single
 func ShowRestoreSingleResult(result *restoremodel.RestoreResult) {
-	ui.PrintSubHeader("Hasil Restore")
+	print.PrintSubHeader("Hasil Restore")
 	fmt.Println()
 
 	fmt.Printf("  %-20s: %s\n", "Target Database", result.TargetDB)
@@ -44,7 +44,7 @@ func ShowRestoreSingleResult(result *restoremodel.RestoreResult) {
 
 // ShowRestorePrimaryResult menampilkan hasil restore primary
 func ShowRestorePrimaryResult(result *restoremodel.RestoreResult) {
-	ui.PrintSubHeader("Hasil Restore Primary")
+	print.PrintSubHeader("Hasil Restore Primary")
 	fmt.Println()
 
 	fmt.Printf("  %-20s: %s\n", "Target Database", result.TargetDB)
@@ -87,7 +87,7 @@ func ShowRestorePrimaryResult(result *restoremodel.RestoreResult) {
 
 // ShowRestoreSecondaryResult menampilkan hasil restore secondary
 func ShowRestoreSecondaryResult(result *restoremodel.RestoreResult) {
-	ui.PrintSubHeader("Hasil Restore Secondary")
+	print.PrintSubHeader("Hasil Restore Secondary")
 	fmt.Println()
 
 	fmt.Printf("  %-20s: %s\n", "Target Database", result.TargetDB)
@@ -117,7 +117,7 @@ func ShowRestoreSecondaryResult(result *restoremodel.RestoreResult) {
 
 // ShowRestoreAllResult menampilkan hasil restore all databases
 func ShowRestoreAllResult(result *restoremodel.RestoreResult) {
-	ui.PrintSubHeader("Hasil Restore All Databases")
+	print.PrintSubHeader("Hasil Restore All Databases")
 	fmt.Println()
 
 	fmt.Printf("  %-20s: %s\n", "Source File", result.SourceFile)
@@ -140,7 +140,7 @@ func ShowRestoreAllResult(result *restoremodel.RestoreResult) {
 
 // ShowRestoreCustomResult menampilkan hasil restore custom (DB + DMART)
 func ShowRestoreCustomResult(result *restoremodel.RestoreResult) {
-	ui.PrintSubHeader("Hasil Restore Custom")
+	print.PrintSubHeader("Hasil Restore Custom")
 	fmt.Println()
 
 	fmt.Printf("  %-20s: %s\n", "Target Database", result.TargetDB)

--- a/internal/app/restore/display/options_display.go
+++ b/internal/app/restore/display/options_display.go
@@ -9,14 +9,15 @@ package display
 import (
 	"errors"
 	"fmt"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
+	"sfDBTools/internal/ui/table"
 	"sort"
 )
 
 // DisplayConfirmation menampilkan konfirmasi sebelum restore
 func DisplayConfirmation(opts map[string]string) error {
-	ui.PrintSubHeader("Konfirmasi Restore")
+	print.PrintSubHeader("Konfirmasi Restore")
 	fmt.Println()
 
 	keys := make([]string, 0, len(opts))
@@ -30,10 +31,10 @@ func DisplayConfirmation(opts map[string]string) error {
 		rows = append(rows, []string{k, opts[k]})
 	}
 
-	ui.FormatTable([]string{"Parameter", "Value"}, rows)
+	table.Render([]string{"Parameter", "Value"}, rows)
 	fmt.Println()
 
-	confirmed, err := input.PromptConfirm("Lanjutkan restore?")
+	confirmed, err := prompt.PromptConfirm("Lanjutkan restore?")
 	if err != nil {
 		return fmt.Errorf("gagal mendapatkan konfirmasi: %w", err)
 	}

--- a/internal/app/restore/helpers/mysql.go
+++ b/internal/app/restore/helpers/mysql.go
@@ -14,12 +14,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/progress"
 	"sfDBTools/pkg/compress"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/encrypt"
 	"sfDBTools/pkg/helper"
 	profilehelper "sfDBTools/pkg/helper/profile"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -66,7 +66,7 @@ func ExecuteMySQLCommand(ctx context.Context, args []string, stdin io.Reader) er
 
 // RestoreFromFile melakukan restore database dari file backup
 func RestoreFromFile(ctx context.Context, filePath string, targetDB string, profile *domain.ProfileInfo, encryptionKey string) error {
-	spin := ui.NewSpinnerWithElapsed(fmt.Sprintf("Restore database %s dari %s", targetDB, filepath.Base(filePath)))
+	spin := progress.NewSpinnerWithElapsed(fmt.Sprintf("Restore database %s dari %s", targetDB, filepath.Base(filePath)))
 	spin.Start()
 	defer spin.Stop()
 
@@ -142,7 +142,7 @@ func RestoreUserGrants(ctx context.Context, grantsFile string, profile *domain.P
 		return nil
 	}
 
-	spin := ui.NewSpinnerWithElapsed(fmt.Sprintf("Restore user grants dari %s", filepath.Base(grantsFile)))
+	spin := progress.NewSpinnerWithElapsed(fmt.Sprintf("Restore user grants dari %s", filepath.Base(grantsFile)))
 	spin.Start()
 	defer spin.Stop()
 

--- a/internal/app/restore/helpers/validation.go
+++ b/internal/app/restore/helpers/validation.go
@@ -2,16 +2,16 @@
 // Deskripsi : Helper functions untuk validation
 // Author : Hadiyatna Muflihun
 // Tanggal : 17 Desember 2025
-// Last Modified : 17 Desember 2025
+// Last Modified : 5 Januari 2026
 
 package helpers
 
 import (
 	"context"
 	"fmt"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/database"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -48,10 +48,10 @@ func ValidatePrimaryDatabaseName(dbName string) error {
 		return nil
 	}
 
-	ui.PrintError("⛔ Restore primary hanya diizinkan ke database primary!")
-	ui.PrintError(fmt.Sprintf("   Database: %s", dbName))
-	ui.PrintError("   Pattern: dbsf_nbc_{client-code} atau dbsf_biznet_{client-code}")
-	ui.PrintError("   Catatan: tanpa suffix '_secondary', '_dmart', '_temp', atau '_archive'")
+	print.PrintError("⛔ Restore primary hanya diizinkan ke database primary!")
+	print.PrintError(fmt.Sprintf("   Database: %s", dbName))
+	print.PrintError("   Pattern: dbsf_nbc_{client-code} atau dbsf_biznet_{client-code}")
+	print.PrintError("   Catatan: tanpa suffix '_secondary', '_dmart', '_temp', atau '_archive'")
 	return fmt.Errorf("target database '%s' bukan database primary yang valid", dbName)
 }
 
@@ -62,10 +62,10 @@ func ValidateNotPrimaryDatabaseName(dbName string) error {
 		return nil
 	}
 
-	ui.PrintError("⛔ Restore single ke database primary tidak diizinkan!")
-	ui.PrintError(fmt.Sprintf("   Database: %s", dbName))
-	ui.PrintError("   Pattern primary: dbsf_nbc_{client-code} atau dbsf_biznet_{client-code}")
-	ui.PrintInfo("💡 Saran: gunakan mode 'restore primary' atau restore ke database non-primary (mis: _secondary/_temp/_archive)")
+	print.PrintError("⛔ Restore single ke database primary tidak diizinkan!")
+	print.PrintError(fmt.Sprintf("   Database: %s", dbName))
+	print.PrintError("   Pattern primary: dbsf_nbc_{client-code} atau dbsf_biznet_{client-code}")
+	print.PrintInfo("💡 Saran: gunakan mode 'restore primary' atau restore ke database non-primary (mis: _secondary/_temp/_archive)")
 	return fmt.Errorf("restore single ke database primary '%s' tidak diizinkan", dbName)
 }
 

--- a/internal/app/restore/modes/all_processing.go
+++ b/internal/app/restore/modes/all_processing.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"sfDBTools/internal/app/restore/helpers"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 	"strings"
 	"time"
 )
@@ -65,13 +65,13 @@ func (e *AllExecutor) executeDryRun(ctx context.Context, opts *restoremodel.Rest
 	}
 
 	// Print hasil analisis
-	ui.PrintSuccess("\n📊 Hasil Analisis File Dump:")
-	ui.PrintInfo(fmt.Sprintf("Total database yang akan di-restore: %d", len(dbStats)))
+	print.PrintSuccess("\n📊 Hasil Analisis File Dump:")
+	print.PrintInfo(fmt.Sprintf("Total database yang akan di-restore: %d", len(dbStats)))
 
 	if len(dbStats) > 0 {
-		ui.PrintInfo("\nDatabase yang akan di-restore:")
+		print.PrintInfo("\nDatabase yang akan di-restore:")
 		for db, lines := range dbStats {
-			ui.PrintInfo(fmt.Sprintf("  • %s (%d baris)", db, lines))
+			print.PrintInfo(fmt.Sprintf("  • %s (%d baris)", db, lines))
 		}
 	}
 

--- a/internal/app/restore/modes/common_helpers.go
+++ b/internal/app/restore/modes/common_helpers.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"sfDBTools/internal/app/restore/helpers"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 	"strings"
 	"time"
 )
@@ -71,7 +71,7 @@ func performPostRestoreOperations(ctx context.Context, service RestoreService, p
 	tempDB, err := service.CreateTempDatabaseIfNeeded(ctx, primaryDB)
 	if err != nil {
 		logger.Warnf("Gagal membuat temp DB: %v", err)
-		ui.PrintWarning(fmt.Sprintf("⚠️  Restore berhasil, tapi gagal membuat temp DB: %v", err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Restore berhasil, tapi gagal membuat temp DB: %v", err))
 		return
 	}
 
@@ -82,7 +82,7 @@ func performPostRestoreOperations(ctx context.Context, service RestoreService, p
 	// Copy grants ke temp database
 	if err := service.CopyDatabaseGrants(ctx, primaryDB, tempDB); err != nil {
 		logger.Warnf("Gagal copy grants ke temp DB: %v", err)
-		ui.PrintWarning(fmt.Sprintf("⚠️  Restore berhasil, tapi gagal copy grants ke temp DB: %v", err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Restore berhasil, tapi gagal copy grants ke temp DB: %v", err))
 	}
 }
 
@@ -96,7 +96,7 @@ func performGrantsRestore(ctx context.Context, service RestoreService, grantsFil
 	grantsRestored, err := service.RestoreUserGrantsIfAvailable(ctx, grantsFile)
 	if err != nil {
 		logger.Errorf("Gagal restore user grants: %v", err)
-		ui.PrintWarning(fmt.Sprintf("⚠️  Database berhasil di-restore, tapi gagal restore user grants: %v", err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Database berhasil di-restore, tapi gagal restore user grants: %v", err))
 		return false
 	}
 
@@ -108,7 +108,7 @@ func copyGrantsBetweenDatabases(ctx context.Context, service RestoreService, sou
 	logger := service.GetLogger()
 	if err := service.CopyDatabaseGrants(ctx, sourceDB, targetDB); err != nil {
 		logger.Warnf("Gagal copy grants %s -> %s: %v", sourceDB, targetDB, err)
-		ui.PrintWarning(fmt.Sprintf("⚠️  Restore berhasil, tapi gagal copy grants %s -> %s: %v", sourceDB, targetDB, err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Restore berhasil, tapi gagal copy grants %s -> %s: %v", sourceDB, targetDB, err))
 	}
 }
 

--- a/internal/app/restore/modes/companion_helpers.go
+++ b/internal/app/restore/modes/companion_helpers.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -69,7 +69,7 @@ func (f *companionRestoreFlow) execute() (backupFile string, err error) {
 		if f.stopOnError {
 			return backupFile, fmt.Errorf("gagal restore companion database: %w", err)
 		}
-		ui.PrintWarning(fmt.Sprintf("⚠️  Gagal restore companion %s: %v", companionDB, err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Gagal restore companion %s: %v", companionDB, err))
 		return backupFile, err
 	}
 
@@ -98,7 +98,7 @@ func backupPrimaryCompanionIfNeeded(ctx context.Context, service RestoreService,
 	}
 
 	if !exists {
-		ui.PrintWarning(fmt.Sprintf("⚠️  Companion %s tidak ditemukan (skip backup)", companionDB))
+		print.PrintWarning(fmt.Sprintf("⚠️  Companion %s tidak ditemukan (skip backup)", companionDB))
 		return "", nil
 	}
 
@@ -108,7 +108,7 @@ func backupPrimaryCompanionIfNeeded(ctx context.Context, service RestoreService,
 		if stopOnError {
 			return "", fmt.Errorf("gagal backup companion %s: %w", companionDB, err)
 		}
-		ui.PrintWarning(fmt.Sprintf("⚠️  Gagal backup companion %s: %v", companionDB, err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Gagal backup companion %s: %v", companionDB, err))
 		return "", nil
 	}
 

--- a/internal/app/restore/modes/custom.go
+++ b/internal/app/restore/modes/custom.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"path/filepath"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 	"strings"
 	"time"
 )
@@ -42,7 +42,7 @@ func (e *customExecutor) Execute(ctx context.Context) (*restoremodel.RestoreResu
 
 	// For dry-run, validate files exist (already validated in setup), and stop here.
 	if opts.DryRun {
-		ui.PrintWarning("Dry-run: tidak ada perubahan database/user yang dilakukan")
+		print.PrintWarning("Dry-run: tidak ada perubahan database/user yang dilakukan")
 		result.Duration = time.Since(start).String()
 		return result, nil
 	}
@@ -128,7 +128,7 @@ func (e *customExecutor) Execute(ctx context.Context) (*restoremodel.RestoreResu
 		copyGrantsBetweenDatabases(ctx, e.svc, opts.Database, opts.DatabaseDmart)
 	}
 
-	ui.PrintSuccess("Restore custom selesai")
+	print.PrintSuccess("Restore custom selesai")
 	result.Duration = time.Since(start).String()
 	return result, nil
 }

--- a/internal/app/restore/modes/dryrun_helpers.go
+++ b/internal/app/restore/modes/dryrun_helpers.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 	"time"
 )
 
@@ -51,12 +51,12 @@ func (v *dryRunValidator) validateDatabaseStatus(dbName string) (bool, error) {
 
 // printSummary mencetak ringkasan validasi dry-run
 func (v *dryRunValidator) printSummary(info map[string]string, warnings []string) {
-	ui.PrintSuccess("\n✓ Validasi File Backup:")
+	print.PrintSuccess("\n✓ Validasi File Backup:")
 	for key, value := range info {
-		ui.PrintInfo(fmt.Sprintf("  %s: %s", key, value))
+		print.PrintInfo(fmt.Sprintf("  %s: %s", key, value))
 	}
 	for _, warning := range warnings {
-		ui.PrintWarning(fmt.Sprintf("  %s", warning))
+		print.PrintWarning(fmt.Sprintf("  %s", warning))
 	}
 }
 

--- a/internal/app/restore/modes/primary.go
+++ b/internal/app/restore/modes/primary.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 	"strings"
 	"time"
 )
@@ -55,7 +55,7 @@ func (e *PrimaryExecutor) Execute(ctx context.Context) (*restoremodel.RestoreRes
 			result.CompanionDB = opts.TargetDB + consts.SuffixDmart
 		} else {
 			logger.Warn("Companion (dmart) diaktifkan tapi file tidak tersedia; skip restore companion")
-			ui.PrintWarning("⚠️  Companion (dmart) diaktifkan tapi file tidak tersedia; skip restore companion")
+			print.PrintWarning("⚠️  Companion (dmart) diaktifkan tapi file tidak tersedia; skip restore companion")
 		}
 	}
 
@@ -129,7 +129,7 @@ func (e *PrimaryExecutor) restoreCompanionDatabase(ctx context.Context, opts *re
 
 	backupFile, err := flow.execute()
 	if err != nil {
-		ui.PrintWarning(fmt.Sprintf("⚠️  Gagal restore companion database %s: %v", companionDB, err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Gagal restore companion database %s: %v", companionDB, err))
 		return err
 	}
 

--- a/internal/app/restore/modes/secondary.go
+++ b/internal/app/restore/modes/secondary.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 	"strings"
 	"time"
 )
@@ -70,14 +70,14 @@ func (e *SecondaryExecutor) Execute(ctx context.Context) (*restoremodel.RestoreR
 	// Dry-run: validate inputs only (no restore)
 	if opts.DryRun {
 		logger.Info("Mode DRY-RUN: validasi file tanpa restore...")
-		ui.PrintInfo(fmt.Sprintf("  Source File: %s", sourceFile))
-		ui.PrintInfo(fmt.Sprintf("  Target DB: %s", opts.TargetDB))
+		print.PrintInfo(fmt.Sprintf("  Source File: %s", sourceFile))
+		print.PrintInfo(fmt.Sprintf("  Target DB: %s", opts.TargetDB))
 		if opts.IncludeDmart {
 			if strings.TrimSpace(companionSourceFile) != "" {
-				ui.PrintInfo(fmt.Sprintf("  Companion File: %s", companionSourceFile))
-				ui.PrintInfo(fmt.Sprintf("  Companion DB: %s", opts.TargetDB+consts.SuffixDmart))
+				print.PrintInfo(fmt.Sprintf("  Companion File: %s", companionSourceFile))
+				print.PrintInfo(fmt.Sprintf("  Companion DB: %s", opts.TargetDB+consts.SuffixDmart))
 			} else {
-				ui.PrintWarning("  Companion (dmart): not available / skipped")
+				print.PrintWarning("  Companion (dmart): not available / skipped")
 			}
 		}
 		result.Success = true

--- a/internal/app/restore/modes/selection.go
+++ b/internal/app/restore/modes/selection.go
@@ -14,8 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 	"strings"
 	"time"
 )
@@ -132,9 +132,9 @@ func (e *selectionExecutor) Execute(ctx context.Context) (*restoremodel.RestoreR
 	// Print summary
 	summary := tracker.getSummary()
 	if tracker.isAllSuccess() {
-		ui.PrintSuccess("Hasil: " + summary)
+		print.PrintSuccess("Hasil: " + summary)
 	} else {
-		ui.PrintWarning("Hasil: " + summary)
+		print.PrintWarning("Hasil: " + summary)
 	}
 
 	return &restoremodel.RestoreResult{

--- a/internal/app/restore/modes/source_helpers.go
+++ b/internal/app/restore/modes/source_helpers.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -82,7 +82,7 @@ func (r *sourceFileResolver) backupCompanionIfExists() (companionSourceFile stri
 	}
 
 	if !exists {
-		ui.PrintWarning(fmt.Sprintf("⚠️  Companion %s tidak ditemukan (skip)", companionDB))
+		print.PrintWarning(fmt.Sprintf("⚠️  Companion %s tidak ditemukan (skip)", companionDB))
 		return "", nil
 	}
 
@@ -92,7 +92,7 @@ func (r *sourceFileResolver) backupCompanionIfExists() (companionSourceFile stri
 		if r.stopOnError {
 			return "", fmt.Errorf("gagal backup companion %s: %w", companionDB, err)
 		}
-		ui.PrintWarning(fmt.Sprintf("⚠️  Gagal backup companion %s: %v", companionDB, err))
+		print.PrintWarning(fmt.Sprintf("⚠️  Gagal backup companion %s: %v", companionDB, err))
 		return "", nil
 	}
 

--- a/internal/app/restore/setup_all_edit.go
+++ b/internal/app/restore/setup_all_edit.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/input"
+	"sfDBTools/internal/ui/prompt"
 	"strings"
 )
 
@@ -27,7 +27,7 @@ func (s *Service) editRestoreAllOptionsInteractive() error {
 		"Kembali",
 	}
 
-	choice, err := input.SelectSingleFromList(options, "Pilih opsi yang ingin diubah")
+	choice, _, err := prompt.SelectOne("Pilih opsi yang ingin diubah", options, 0)
 	if err != nil {
 		return fmt.Errorf("gagal memilih opsi untuk diubah: %w", err)
 	}
@@ -106,7 +106,7 @@ func (s *Service) changeAllTicket() error {
 }
 
 func (s *Service) changeAllDropTarget() error {
-	val, err := input.AskYesNo("Drop semua database non-sistem sebelum restore?", s.RestoreAllOpts.DropTarget)
+	val, err := prompt.Confirm("Drop semua database non-sistem sebelum restore?", s.RestoreAllOpts.DropTarget)
 	if err != nil {
 		return fmt.Errorf("gagal mengubah opsi drop-target: %w", err)
 	}
@@ -116,7 +116,7 @@ func (s *Service) changeAllDropTarget() error {
 
 func (s *Service) changeAllContinueOnError() error {
 	defaultContinue := !s.RestoreAllOpts.StopOnError
-	cont, err := input.AskYesNo("Lanjutkan meski ada error? (continue-on-error)", defaultContinue)
+	cont, err := prompt.Confirm("Lanjutkan meski ada error? (continue-on-error)", defaultContinue)
 	if err != nil {
 		return fmt.Errorf("gagal mengubah opsi continue-on-error: %w", err)
 	}
@@ -125,7 +125,7 @@ func (s *Service) changeAllContinueOnError() error {
 }
 
 func (s *Service) changeAllSkipGrants() error {
-	skip, err := input.AskYesNo("Skip restore user grants?", s.RestoreAllOpts.SkipGrants)
+	skip, err := prompt.Confirm("Skip restore user grants?", s.RestoreAllOpts.SkipGrants)
 	if err != nil {
 		return fmt.Errorf("gagal mengubah opsi skip-grants: %w", err)
 	}
@@ -141,7 +141,7 @@ func (s *Service) changeAllSkipGrants() error {
 }
 
 func (s *Service) changeAllSkipBackup() error {
-	skip, err := input.AskYesNo("Skip backup sebelum restore?", s.RestoreAllOpts.SkipBackup)
+	skip, err := prompt.Confirm("Skip backup sebelum restore?", s.RestoreAllOpts.SkipBackup)
 	if err != nil {
 		return fmt.Errorf("gagal mengubah opsi skip-backup: %w", err)
 	}
@@ -170,7 +170,7 @@ func (s *Service) changeAllBackupDirectory() error {
 		}
 	}
 
-	dir, err := input.AskString("Direktori backup pre-restore", current, nil)
+	dir, err := prompt.AskText("Direktori backup pre-restore", prompt.WithDefault(current))
 	if err != nil {
 		return fmt.Errorf("gagal mengubah direktori backup: %w", err)
 	}

--- a/internal/app/restore/setup_custom.go
+++ b/internal/app/restore/setup_custom.go
@@ -15,13 +15,13 @@ import (
 
 	"sfDBTools/internal/app/restore/display"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 )
 
 func (s *Service) SetupRestoreCustomSession(ctx context.Context) error {
-	ui.Headers("Restore Custom")
+	print.PrintAppHeader("Restore Custom")
 
 	opts := s.GetCustomOptions()
 	if opts == nil {
@@ -61,7 +61,7 @@ func (s *Service) SetupRestoreCustomSession(ctx context.Context) error {
 	}
 
 	// 6. Prompt paste account detail
-	ui.PrintSubHeader("Paste Account Detail")
+	print.PrintSubHeader("Paste Account Detail")
 	fmt.Println("Paste account detail dari SFCola, lalu Enter dan tekan Ctrl+D")
 
 	pasted, err := readMultilineUntilEndToken("END")
@@ -94,7 +94,7 @@ func (s *Service) SetupRestoreCustomSession(ctx context.Context) error {
 	}
 	validExtensions := helper.ValidBackupFileExtensionsForSelection()
 
-	dbFile, err := input.SelectFileInteractive(defaultDir, "Pilih file backup untuk DATABASE", validExtensions)
+	dbFile, err := prompt.SelectFile(defaultDir, "Pilih file backup untuk DATABASE", validExtensions)
 	if err != nil {
 		return fmt.Errorf("gagal memilih file backup database: %w", err)
 	}
@@ -108,7 +108,7 @@ func (s *Service) SetupRestoreCustomSession(ctx context.Context) error {
 	opts.DatabaseFile = absDB
 
 	// 8. Pilih file backup dmart
-	dmartFile, err := input.SelectFileInteractive(defaultDir, "Pilih file backup untuk DATABASE DMART", validExtensions)
+	dmartFile, err := prompt.SelectFile(defaultDir, "Pilih file backup untuk DATABASE DMART", validExtensions)
 	if err != nil {
 		return fmt.Errorf("gagal memilih file backup dmart: %w", err)
 	}

--- a/internal/app/restore/setup_primary.go
+++ b/internal/app/restore/setup_primary.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"sfDBTools/internal/app/restore/helpers"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 )
 
 // SetupRestorePrimarySession melakukan setup untuk restore primary session
 func (s *Service) SetupRestorePrimarySession(ctx context.Context) error {
-	ui.Headers("Restore Primary Database")
+	print.PrintAppHeader("Restore Primary Database")
 	if s.RestorePrimaryOpts == nil {
 		return fmt.Errorf("opsi primary tidak tersedia")
 	}
@@ -135,7 +135,7 @@ func (s *Service) resolveAndValidatePrimaryDB(ctx context.Context) error {
 // retryPrimaryDatabaseInput memberikan kesempatan user untuk input ulang nama database primary
 func (s *Service) retryPrimaryDatabaseInput(initialErr error) error {
 	for {
-		retry, askErr := input.AskYesNo("Nama target database tidak valid. Input ulang?", true)
+		retry, askErr := prompt.Confirm("Nama target database tidak valid. Input ulang?", true)
 		if askErr != nil || !retry {
 			return initialErr
 		}
@@ -143,10 +143,10 @@ func (s *Service) retryPrimaryDatabaseInput(initialErr error) error {
 		prefix := inferPrimaryPrefixFromTargetOrFile(s.RestorePrimaryOpts.TargetDB, s.RestorePrimaryOpts.File)
 		defaultClientCode := extractClientCodeFromDB(s.RestorePrimaryOpts.TargetDB, prefix)
 
-		newClientCode, inErr := input.AskString(
+		newClientCode, inErr := prompt.AskText(
 			"Masukkan client-code target (contoh: tes123_tes)",
-			defaultClientCode,
-			validatePrimaryClientCodeInput(prefix),
+			prompt.WithDefault(defaultClientCode),
+			prompt.WithValidator(validatePrimaryClientCodeInput(prefix)),
 		)
 		if inErr != nil {
 			return fmt.Errorf("gagal mendapatkan nama database: %w", inErr)
@@ -198,10 +198,10 @@ func (s *Service) resolveTargetDatabasePrimary(ctx context.Context) error {
 	defaultClientCode := extractDefaultClientCodeFromFile(s.RestorePrimaryOpts.File)
 	prefix := inferPrimaryPrefixFromTargetOrFile("", s.RestorePrimaryOpts.File)
 
-	clientCode, err := input.AskString(
+	clientCode, err := prompt.AskText(
 		"Masukkan client-code target (contoh: tes123_tes)",
-		defaultClientCode,
-		validatePrimaryClientCodeInput(prefix),
+		prompt.WithDefault(defaultClientCode),
+		prompt.WithValidator(validatePrimaryClientCodeInput(prefix)),
 	)
 	if err != nil {
 		return fmt.Errorf("gagal mendapatkan client-code: %w", err)

--- a/internal/app/restore/setup_secondary.go
+++ b/internal/app/restore/setup_secondary.go
@@ -10,13 +10,13 @@ import (
 	"fmt"
 	"path/filepath"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 	"strings"
 )
 
 // SetupRestoreSecondarySession melakukan setup untuk restore secondary session
 func (s *Service) SetupRestoreSecondarySession(ctx context.Context) error {
-	ui.Headers("Restore Secondary Database")
+	print.PrintAppHeader("Restore Secondary Database")
 	if s.RestoreSecondaryOpts == nil {
 		return fmt.Errorf("opsi secondary tidak tersedia")
 	}

--- a/internal/app/restore/setup_secondary_companion.go
+++ b/internal/app/restore/setup_secondary_companion.go
@@ -10,9 +10,9 @@ import (
 	"os"
 	"path/filepath"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -61,13 +61,13 @@ func (s *Service) ensureValidCompanionPath(opts *restoremodel.RestoreSecondaryOp
 		if opts.StopOnError {
 			return fmt.Errorf("dmart file (_dmart) tidak ditemukan/invalid: %s", opts.CompanionFile)
 		}
-		ui.PrintWarning("⚠️  Skip restore companion database (_dmart) karena dmart file invalid")
+		print.PrintWarning("⚠️  Skip restore companion database (_dmart) karena dmart file invalid")
 		opts.IncludeDmart = false
 		opts.CompanionFile = ""
 		return nil
 	}
 
-	ui.PrintWarning(fmt.Sprintf("⚠️  Dmart file tidak valid: %s", opts.CompanionFile))
+	print.PrintWarning(fmt.Sprintf("⚠️  Dmart file tidak valid: %s", opts.CompanionFile))
 	opts.CompanionFile = ""
 	return nil
 }
@@ -79,7 +79,7 @@ func (s *Service) enforceForceWithoutDetect(opts *restoremodel.RestoreSecondaryO
 	if opts.StopOnError {
 		return fmt.Errorf("auto-detect dmart dimatikan (dmart-detect=false) dan mode non-interaktif (--force) aktif")
 	}
-	ui.PrintWarning("⚠️  Skip restore companion database (_dmart) (non-interaktif, companion tidak ditentukan)")
+	print.PrintWarning("⚠️  Skip restore companion database (_dmart) (non-interaktif, companion tidak ditentukan)")
 	opts.IncludeDmart = false
 	return nil
 }
@@ -89,7 +89,7 @@ func (s *Service) handleManualCompanionSelection(opts *restoremodel.RestoreSecon
 		return nil
 	}
 
-	confirmed, err := input.AskYesNo("Pilih file companion (_dmart) secara manual?", true)
+	confirmed, err := prompt.Confirm("Pilih file companion (_dmart) secara manual?", true)
 	if err != nil || !confirmed {
 		opts.IncludeDmart = false
 		return nil
@@ -117,7 +117,7 @@ func (s *Service) handleCompanionNotFound(opts *restoremodel.RestoreSecondaryOpt
 		if opts.StopOnError {
 			return fmt.Errorf("dmart file (_dmart) tidak ditemukan secara otomatis")
 		}
-		ui.PrintWarning("⚠️  Skip restore companion database (_dmart) (companion tidak ditemukan)")
+		print.PrintWarning("⚠️  Skip restore companion database (_dmart) (companion tidak ditemukan)")
 		opts.IncludeDmart = false
 		return nil
 	}
@@ -141,7 +141,7 @@ func (s *Service) handleCompanionNotFound(opts *restoremodel.RestoreSecondaryOpt
 
 func (s *Service) selectDmartFileInteractive(dir string) (string, error) {
 	validExtensions := helper.ValidBackupFileExtensionsForSelection()
-	selectedFile, err := input.SelectFileInteractive(dir, "Masukkan path directory atau file dmart", validExtensions)
+	selectedFile, err := prompt.SelectFile(dir, "Masukkan path directory atau file dmart", validExtensions)
 	if err != nil {
 		return "", fmt.Errorf("gagal memilih dmart file: %w", err)
 	}
@@ -149,11 +149,11 @@ func (s *Service) selectDmartFileInteractive(dir string) (string, error) {
 }
 
 func decideSecondaryCompanionNotFoundInteractive() (bool, error) {
-	ui.PrintWarning("⚠️  Companion (_dmart) file tidak ditemukan secara otomatis")
-	selected, err := input.SelectSingleFromList([]string{
+	print.PrintWarning("⚠️  Companion (_dmart) file tidak ditemukan secara otomatis")
+	selected, _, err := prompt.SelectOne("Pilih tindakan untuk companion (_dmart)", []string{
 		"📁 [ Browse / pilih dmart file ]",
 		"⏭️  [ Skip restore companion database (_dmart) ]",
-	}, "Pilih tindakan untuk companion (_dmart)")
+	}, 0)
 	if err != nil {
 		return false, fmt.Errorf("gagal memilih opsi companion: %w", err)
 	}

--- a/internal/app/restore/setup_secondary_helpers.go
+++ b/internal/app/restore/setup_secondary_helpers.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
 	"strings"
 )
 
@@ -19,7 +19,7 @@ func (s *Service) resolveSecondaryFrom(opts *restoremodel.RestoreSecondaryOption
 	from := normalizeRestoreSource(opts.From)
 	if from == "" {
 		if allowInteractive {
-			selected, err := input.SelectSingleFromList(validSecondarySources(), "Pilih mode restore secondary (source)")
+			selected, _, err := prompt.SelectOne("Pilih mode restore secondary (source)", validSecondarySources(), 0)
 			if err != nil {
 				return fmt.Errorf("gagal memilih mode restore secondary: %w", err)
 			}
@@ -33,7 +33,7 @@ func (s *Service) resolveSecondaryFrom(opts *restoremodel.RestoreSecondaryOption
 		if !allowInteractive {
 			return fmt.Errorf("nilai --from tidak valid: %s (gunakan: primary atau file)", from)
 		}
-		selected, err := input.SelectSingleFromList(validSecondarySources(), "Pilih sumber restore secondary")
+		selected, _, err := prompt.SelectOne("Pilih sumber restore secondary", validSecondarySources(), 0)
 		if err != nil {
 			return fmt.Errorf("gagal memilih --from: %w", err)
 		}
@@ -52,7 +52,7 @@ func (s *Service) resolveSecondaryClientCode(opts *restoremodel.RestoreSecondary
 	if !allowInteractive {
 		return fmt.Errorf("client code wajib diisi (--client-code) pada mode non-interaktif (--force)")
 	}
-	cc, err := input.AskString("Masukkan client code: ", "", validateClientCodeInput)
+	cc, err := prompt.AskText("Masukkan client code: ", prompt.WithValidator(validateClientCodeInput))
 	if err != nil {
 		return fmt.Errorf("gagal mendapatkan client code: %w", err)
 	}
@@ -76,7 +76,7 @@ func (s *Service) resolveSecondaryEncryptionKey(opts *restoremodel.RestoreSecond
 		return fmt.Errorf("encryption key wajib diisi (--encryption-key) karena backup encryption aktif")
 	}
 
-	k, err := input.AskString("Masukkan encryption key untuk file backup (SFDB_BACKUP_ENCRYPTION_KEY): ", "", validateClientCodeInput)
+	k, err := prompt.AskText("Masukkan encryption key untuk file backup (SFDB_BACKUP_ENCRYPTION_KEY): ", prompt.WithValidator(validateClientCodeInput))
 	if err != nil {
 		return fmt.Errorf("gagal mendapatkan encryption key: %w", err)
 	}

--- a/internal/app/restore/setup_secondary_instance.go
+++ b/internal/app/restore/setup_secondary_instance.go
@@ -9,8 +9,8 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
 	"strings"
 )
 
@@ -51,7 +51,7 @@ func (s *Service) fetchExistingSecondaryInstances(ctx context.Context, primaryDB
 func (s *Service) pickSecondaryInstance(instances []string, primaryDB string) (string, error) {
 	options := buildSecondaryInstanceOptions(instances)
 
-	selected, err := input.SelectSingleFromList(options, "Pilih instance secondary")
+	selected, _, err := prompt.SelectOne("Pilih instance secondary", options, 0)
 	if err != nil {
 		return "", fmt.Errorf("gagal memilih instance: %w", err)
 	}
@@ -67,9 +67,11 @@ func (s *Service) pickSecondaryInstance(instances []string, primaryDB string) (s
 }
 
 func askSecondaryInstanceManual(primaryDB string) (string, error) {
-	val, err := input.AskString("Masukkan instance secondary: ", "training", func(ans interface{}) error {
-		return validateSecondaryInstanceInput(primaryDB, ans)
-	})
+	val, err := prompt.AskText(
+		"Masukkan instance secondary: ",
+		prompt.WithDefault("training"),
+		prompt.WithValidator(func(ans interface{}) error { return validateSecondaryInstanceInput(primaryDB, ans) }),
+	)
 	if err != nil {
 		return "", fmt.Errorf("gagal mendapatkan instance: %w", err)
 	}

--- a/internal/app/restore/setup_selection.go
+++ b/internal/app/restore/setup_selection.go
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"sfDBTools/internal/app/restore/display"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 )
 
 // SetupRestoreSelectionSession melakukan setup untuk restore selection (CSV)
 func (s *Service) SetupRestoreSelectionSession(ctx context.Context) error {
-	ui.Headers("Restore Selection (CSV)")
+	print.PrintAppHeader("Restore Selection (CSV)")
 	if s.RestoreSelOpts == nil {
 		return fmt.Errorf("opsi selection tidak tersedia")
 	}

--- a/internal/app/restore/setup_shared.go
+++ b/internal/app/restore/setup_shared.go
@@ -2,7 +2,7 @@
 // Deskripsi : Shared setup functions untuk restore operations
 // Author : Hadiyatna Muflihun
 // Tanggal : 30 Desember 2025
-// Last Modified : 30 Desember 2025
+// Last Modified : 5 Januari 2026
 
 package restore
 
@@ -12,9 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 )
 
 // resolveBackupFile resolve lokasi file backup
@@ -34,7 +34,7 @@ func (s *Service) resolveSelectionCSV(csvPath *string, allowInteractive bool) er
 }
 
 // resolveFileWithPrompt adalah fungsi umum untuk resolve file dengan validasi dan prompt
-func (s *Service) resolveFileWithPrompt(filePath *string, allowInteractive bool, validExtensions []string, purpose, prompt string) error {
+func (s *Service) resolveFileWithPrompt(filePath *string, allowInteractive bool, validExtensions []string, purpose, promptLabel string) error {
 	if strings.TrimSpace(*filePath) == "" {
 		if !allowInteractive {
 			return fmt.Errorf("%s wajib diisi pada mode non-interaktif (--force)", purpose)
@@ -45,7 +45,7 @@ func (s *Service) resolveFileWithPrompt(filePath *string, allowInteractive bool,
 			defaultDir = "."
 		}
 
-		selectedFile, err := input.SelectFileInteractive(defaultDir, prompt, validExtensions)
+		selectedFile, err := prompt.SelectFile(defaultDir, promptLabel, validExtensions)
 		if err != nil {
 			return fmt.Errorf("gagal memilih %s: %w", purpose, err)
 		}
@@ -67,7 +67,7 @@ func (s *Service) resolveFileWithPrompt(filePath *string, allowInteractive bool,
 			return fmt.Errorf("%s tidak valid (path adalah direktori): %s", purpose, *filePath)
 		}
 
-		selectedFile, selErr := input.SelectFileInteractive(*filePath, prompt, validExtensions)
+		selectedFile, selErr := prompt.SelectFile(*filePath, promptLabel, validExtensions)
 		if selErr != nil {
 			return fmt.Errorf("gagal memilih %s: %w", purpose, selErr)
 		}
@@ -78,8 +78,8 @@ func (s *Service) resolveFileWithPrompt(filePath *string, allowInteractive bool,
 		if !allowInteractive {
 			return err
 		}
-		ui.PrintWarning(fmt.Sprintf("⚠️  %s", err.Error()))
-		selectedFile, selErr := input.SelectFileInteractive(filepath.Dir(*filePath), prompt, validExtensions)
+		print.PrintWarning(fmt.Sprintf("⚠️  %s", err.Error()))
+		selectedFile, selErr := prompt.SelectFile(filepath.Dir(*filePath), promptLabel, validExtensions)
 		if selErr != nil {
 			return fmt.Errorf("gagal memilih %s: %w", purpose, selErr)
 		}

--- a/internal/app/restore/setup_shared_ticket.go
+++ b/internal/app/restore/setup_shared_ticket.go
@@ -2,7 +2,7 @@
 // Deskripsi : Helper ticket dan opsi interaktif keamanan restore
 // Author : Hadiyatna Muflihun
 // Tanggal : 30 Desember 2025
-// Last Modified : 30 Desember 2025
+// Last Modified : 5 Januari 2026
 
 package restore
 
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"strings"
 
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
 )
 
 func (s *Service) resolveTicketNumber(ticket *string, allowInteractive bool) error {
@@ -19,7 +19,7 @@ func (s *Service) resolveTicketNumber(ticket *string, allowInteractive bool) err
 		if !allowInteractive {
 			return fmt.Errorf("ticket number wajib diisi (--ticket) pada mode non-interaktif (--force)")
 		}
-		result, err := input.AskTicket(consts.FeatureRestore)
+		result, err := prompt.AskTicket(consts.FeatureRestore)
 		if err != nil {
 			return fmt.Errorf("gagal mendapatkan ticket number: %w", err)
 		}
@@ -41,7 +41,7 @@ func (s *Service) resolveInteractiveSafetyOptions(dropTarget *bool, skipBackup *
 	if skipBackup != nil {
 		backupDefault = !*skipBackup
 	}
-	shouldBackup, err := input.AskYesNo("Lakukan backup sebelum restore?", backupDefault)
+	shouldBackup, err := prompt.Confirm("Lakukan backup sebelum restore?", backupDefault)
 	if err != nil {
 		return fmt.Errorf("gagal mendapatkan pilihan backup pre-restore: %w", err)
 	}
@@ -53,7 +53,7 @@ func (s *Service) resolveInteractiveSafetyOptions(dropTarget *bool, skipBackup *
 	if dropTarget != nil {
 		dropDefault = *dropTarget
 	}
-	shouldDrop, err := input.AskYesNo("Drop target database sebelum restore?", dropDefault)
+	shouldDrop, err := prompt.Confirm("Drop target database sebelum restore?", dropDefault)
 	if err != nil {
 		return fmt.Errorf("gagal mendapatkan pilihan drop target: %w", err)
 	}
@@ -89,7 +89,7 @@ func (s *Service) getBackupDirectory(allowInteractive bool) string {
 	fmt.Printf("   Default directory: %s\n", defaultDir)
 	fmt.Println()
 
-	backupDir, err := input.AskString("Masukkan direktori untuk backup pre-restore (kosongkan untuk default)", defaultDir, nil)
+	backupDir, err := prompt.AskText("Masukkan direktori untuk backup pre-restore (kosongkan untuk default)", prompt.WithDefault(defaultDir))
 	if err != nil {
 		s.Log.Warnf("Gagal mendapatkan input direktori backup, menggunakan default: %v", err)
 		return defaultDir

--- a/internal/app/restore/setup_single_edit.go
+++ b/internal/app/restore/setup_single_edit.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	restoremodel "sfDBTools/internal/app/restore/model"
-	"sfDBTools/pkg/input"
+	"sfDBTools/internal/ui/prompt"
 	"strings"
 )
 
@@ -27,7 +27,7 @@ func (s *Service) editRestoreSingleOptionsInteractive() error {
 		"Kembali",
 	}
 
-	choice, err := input.SelectSingleFromList(options, "Pilih opsi yang ingin diubah")
+	choice, _, err := prompt.SelectOne("Pilih opsi yang ingin diubah", options, 0)
 	if err != nil {
 		return fmt.Errorf("gagal memilih opsi untuk diubah: %w", err)
 	}
@@ -114,7 +114,7 @@ func (s *Service) changeSingleTicket() error {
 }
 
 func (s *Service) changeSingleDropTarget() error {
-	val, err := input.AskYesNo("Drop target database sebelum restore?", s.RestoreOpts.DropTarget)
+	val, err := prompt.Confirm("Drop target database sebelum restore?", s.RestoreOpts.DropTarget)
 	if err != nil {
 		return fmt.Errorf("gagal mengubah opsi drop-target: %w", err)
 	}
@@ -123,7 +123,7 @@ func (s *Service) changeSingleDropTarget() error {
 }
 
 func (s *Service) changeSingleSkipGrants() error {
-	skip, err := input.AskYesNo("Skip restore user grants?", s.RestoreOpts.SkipGrants)
+	skip, err := prompt.Confirm("Skip restore user grants?", s.RestoreOpts.SkipGrants)
 	if err != nil {
 		return fmt.Errorf("gagal mengubah opsi skip-grants: %w", err)
 	}
@@ -139,7 +139,7 @@ func (s *Service) changeSingleSkipGrants() error {
 }
 
 func (s *Service) changeSingleSkipBackup() error {
-	skip, err := input.AskYesNo("Skip backup sebelum restore?", s.RestoreOpts.SkipBackup)
+	skip, err := prompt.Confirm("Skip backup sebelum restore?", s.RestoreOpts.SkipBackup)
 	if err != nil {
 		return fmt.Errorf("gagal mengubah opsi skip-backup: %w", err)
 	}
@@ -168,7 +168,7 @@ func (s *Service) changeSingleBackupDirectory() error {
 		}
 	}
 
-	dir, err := input.AskString("Direktori backup pre-restore", current, nil)
+	dir, err := prompt.AskText("Direktori backup pre-restore", prompt.WithDefault(current))
 	if err != nil {
 		return fmt.Errorf("gagal mengubah direktori backup: %w", err)
 	}

--- a/internal/app/restore/setup_validators.go
+++ b/internal/app/restore/setup_validators.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"sfDBTools/internal/app/restore/helpers"
 	restoremodel "sfDBTools/internal/app/restore/model"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -71,7 +71,7 @@ func (s *Service) validateAndRetryEncryptionKey(filePath string, encryptionKey *
 			if !allowInteractive {
 				return fmt.Errorf("file backup terenkripsi; encryption key wajib diisi (--enc-key atau env) pada mode non-interaktif (--force)")
 			}
-			key, err := input.PromptPassword("Masukkan encryption key untuk decrypt file backup")
+			key, err := prompt.PromptPassword("Masukkan encryption key untuk decrypt file backup")
 			if err != nil {
 				return fmt.Errorf("gagal mendapatkan encryption key: %w", err)
 			}
@@ -85,10 +85,11 @@ func (s *Service) validateAndRetryEncryptionKey(filePath string, encryptionKey *
 				return fmt.Errorf("validasi encryption key gagal: %w", err)
 			}
 
-			ui.PrintError(fmt.Sprintf("Encryption key tidak valid atau file gagal didecrypt: %v", err))
-			action, selErr := input.SelectSingleFromList(
-				[]string{"Ubah key enkripsi", "Batalkan"},
+			print.PrintError(fmt.Sprintf("Encryption key tidak valid atau file gagal didecrypt: %v", err))
+			action, _, selErr := prompt.SelectOne(
 				"Encryption key salah. Pilih aksi:",
+				[]string{"Ubah key enkripsi", "Batalkan"},
+				0,
 			)
 			if selErr != nil {
 				return fmt.Errorf("gagal memilih aksi setelah error encryption key: %w", selErr)
@@ -200,11 +201,11 @@ func (s *Service) validateCompanionFile(opts interface{}, allowInteractive bool)
 		if stopOnError {
 			return fmt.Errorf("dmart file (_dmart) tidak ditemukan/invalid: %s", companionFile)
 		}
-		ui.PrintWarning("⚠️  Skip restore companion database (_dmart) karena dmart file invalid")
+		print.PrintWarning("⚠️  Skip restore companion database (_dmart) karena dmart file invalid")
 		*includeDmart = false
 		return nil
 	}
 
-	ui.PrintWarning(fmt.Sprintf("⚠️  Dmart file tidak valid: %s", companionFile))
+	print.PrintWarning(fmt.Sprintf("⚠️  Dmart file tidak valid: %s", companionFile))
 	return nil
 }

--- a/internal/app/restore/validation_helpers.go
+++ b/internal/app/restore/validation_helpers.go
@@ -9,9 +9,9 @@ import (
 	"context"
 	"fmt"
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"strings"
 )
 
@@ -20,7 +20,7 @@ func (s *Service) validateApplicationPassword() error {
 	s.Log.Info("Meminta password aplikasi untuk validasi restore primary")
 
 	// Prompt password
-	password, err := input.PromptPassword("Masukkan password aplikasi untuk melanjutkan restore primary:")
+	password, err := prompt.PromptPassword("Masukkan password aplikasi untuk melanjutkan restore primary:")
 	if err != nil {
 		return fmt.Errorf("gagal membaca password: %w", err)
 	}
@@ -32,7 +32,7 @@ func (s *Service) validateApplicationPassword() error {
 	}
 
 	s.Log.Info("Password aplikasi valid, melanjutkan restore")
-	ui.PrintSuccess("✓ Password aplikasi valid")
+	print.PrintSuccess("✓ Password aplikasi valid")
 
 	return nil
 }

--- a/internal/app/script/extract.go
+++ b/internal/app/script/extract.go
@@ -7,10 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	scriptmodel "sfDBTools/internal/app/script/model"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/encrypt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/input"
 	"strings"
 )
 
@@ -34,7 +34,7 @@ func ExtractBundle(opts scriptmodel.ScriptExtractOptions) error {
 	}
 
 	// Proteksi ganda: setelah key, wajib password aplikasi.
-	password, err := input.PromptPassword("Masukkan password aplikasi untuk melanjutkan extract:")
+	password, err := prompt.AskPassword("Masukkan password aplikasi untuk melanjutkan extract:", nil)
 	if err != nil {
 		return fmt.Errorf("gagal membaca password aplikasi: %w", err)
 	}

--- a/internal/jobs/command.go
+++ b/internal/jobs/command.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"sfDBTools/internal/services/scheduler"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 )
 
 type ListOutput struct {
@@ -56,17 +56,17 @@ func PrintList(ctx context.Context, scope scheduler.Scope, isRoot bool) error {
 // PrintListBody menampilkan list jobs tanpa mencetak header utama.
 // Dipakai oleh mode interaktif agar header tidak dobel.
 func PrintListBody(ctx context.Context, scope scheduler.Scope, isRoot bool) error {
-	ui.PrintInfo("Menampilkan unit sfdbtools (service + timer)")
-	ui.PrintInfo("Tip: gunakan --scope=system bila scheduler dijalankan via sudo")
+	print.PrintInfo("Menampilkan unit sfdbtools (service + timer)")
+	print.PrintInfo("Tip: gunakan --scope=system bila scheduler dijalankan via sudo")
 
 	out, err := List(ctx, scope)
 	if err != nil {
-		ui.PrintWarning(fmt.Sprintf("Gagal list jobs (scope=%s): %v", scope, err))
+		print.PrintWarn(fmt.Sprintf("Gagal list jobs (scope=%s): %v", scope, err))
 		return err
 	}
 
 	if out.Timers != "" {
-		ui.PrintInfo(fmt.Sprintf("Timers (scope=%s)", out.UsedTimers))
+		print.PrintInfo(fmt.Sprintf("Timers (scope=%s)", out.UsedTimers))
 		v := strings.TrimSpace(out.Timers)
 		if v == "" {
 			fmt.Println("- (tidak ada)")
@@ -74,13 +74,13 @@ func PrintListBody(ctx context.Context, scope scheduler.Scope, isRoot bool) erro
 			fmt.Println(v)
 		}
 	} else {
-		ui.PrintInfo("Timers")
+		print.PrintInfo("Timers")
 		fmt.Println("- (tidak ada)")
 	}
 
-	ui.PrintSeparator()
+	print.PrintSeparator()
 
-	ui.PrintInfo(fmt.Sprintf("Services (scope=%s)", out.UsedServices))
+	print.PrintInfo(fmt.Sprintf("Services (scope=%s)", out.UsedServices))
 	v := strings.TrimSpace(out.Services)
 	if v == "" {
 		fmt.Println("- (tidak ada)")
@@ -90,7 +90,7 @@ func PrintListBody(ctx context.Context, scope scheduler.Scope, isRoot bool) erro
 
 	// Hint untuk system scope.
 	if !isRoot && (scope == scheduler.ScopeSystem || scope == scheduler.ScopeBoth) {
-		ui.PrintInfo("Jika ada error permission saat akses system scope, jalankan dengan sudo.")
+		print.PrintInfo("Jika ada error permission saat akses system scope, jalankan dengan sudo.")
 	}
 	return nil
 }

--- a/internal/services/crypto/auth.go
+++ b/internal/services/crypto/auth.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/consts"
-	"sfDBTools/pkg/input"
 )
 
 // ValidatePassword meminta password dari user dan memvalidasi dengan ENV_PASSWORD_APP.
@@ -14,7 +15,7 @@ func ValidatePassword() error {
 	expectedPassword := consts.ENV_PASSWORD_APP
 
 	for {
-		password, err := input.AskPassword("Masukkan password untuk crypto utilities", nil)
+		password, err := prompt.AskPassword("Masukkan password untuk crypto utilities", nil)
 		if err != nil {
 			return fmt.Errorf("gagal membaca password: %w", err)
 		}
@@ -23,8 +24,8 @@ func ValidatePassword() error {
 			return nil
 		}
 
-		fmt.Println("✗ Password salah! Coba lagi atau tekan Ctrl+C untuk batal.")
-		fmt.Println()
+		print.PrintError("Password salah! Coba lagi atau tekan Ctrl+C untuk batal.")
+		print.Println()
 	}
 }
 
@@ -32,9 +33,9 @@ func ValidatePassword() error {
 // Digunakan untuk command yang membutuhkan password mandatory.
 func MustValidatePassword() {
 	if err := ValidatePassword(); err != nil {
-		fmt.Fprintf(os.Stderr, "✗ Autentikasi gagal: %v\n", err)
+		print.PrintError(fmt.Sprintf("Autentikasi gagal: %v", err))
 		os.Exit(1)
 	}
-	fmt.Println("✓ Autentikasi berhasil")
-	fmt.Println()
+	print.PrintSuccess("Autentikasi berhasil")
+	print.Println()
 }

--- a/internal/services/crypto/base64.go
+++ b/internal/services/crypto/base64.go
@@ -9,7 +9,7 @@ import (
 	"sfDBTools/internal/services/crypto/helpers"
 	cryptomodel "sfDBTools/internal/services/crypto/model"
 	applog "sfDBTools/internal/services/log"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/print"
 )
 
 // ExecuteBase64Encode menangani logic base64 encode
@@ -21,11 +21,11 @@ func ExecuteBase64Encode(logger applog.Logger, opts cryptomodel.Base64EncodeOpti
 	}
 
 	enc := base64.StdEncoding.EncodeToString(b)
-	ui.Headers("Base64 Encode")
+	print.PrintAppHeader("Base64 Encode")
 	if strings.TrimSpace(opts.OutputPath) == "" {
-		ui.PrintSubHeader("Output text")
+		print.PrintSubHeader("Output text")
 		fmt.Println(enc)
-		ui.PrintDashedSeparator()
+		print.PrintDashedSeparator()
 		return nil
 	}
 	if err := os.WriteFile(opts.OutputPath, []byte(enc), 0644); err != nil {
@@ -48,11 +48,11 @@ func ExecuteBase64Decode(logger applog.Logger, opts cryptomodel.Base64DecodeOpti
 	if err != nil {
 		return fmt.Errorf("input bukan base64 yang valid: %v", err)
 	}
-	ui.Headers("Base64 Decode")
-	ui.PrintSubHeader("Output Text : ")
+	print.PrintAppHeader("Base64 Decode")
+	print.PrintSubHeader("Output Text : ")
 	if strings.TrimSpace(opts.OutputPath) == "" {
 		fmt.Println(string(b))
-		ui.PrintDashedSeparator()
+		print.PrintDashedSeparator()
 		return nil
 	}
 	if err := os.WriteFile(opts.OutputPath, b, 0644); err != nil {

--- a/internal/services/crypto/file.go
+++ b/internal/services/crypto/file.go
@@ -8,10 +8,10 @@ import (
 	"sfDBTools/internal/services/crypto/helpers"
 	cryptomodel "sfDBTools/internal/services/crypto/model"
 	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/encrypt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 )
 
 // ExecuteEncryptFile menangani logic encrypt file
@@ -22,7 +22,7 @@ func ExecuteEncryptFile(logger applog.Logger, opts cryptomodel.EncryptFileOption
 	MustValidatePassword()
 
 	if !quiet {
-		ui.Headers("Encrypt File")
+		print.PrintAppHeader("Encrypt File")
 	}
 
 	// Interactive mode untuk file paths jika tidak ada flag
@@ -96,7 +96,7 @@ func ExecuteDecryptFile(logger applog.Logger, opts cryptomodel.DecryptFileOption
 	MustValidatePassword()
 
 	if !quiet {
-		ui.Headers("Decrypt File")
+		print.PrintAppHeader("Decrypt File")
 	}
 
 	// Interactive mode untuk file paths jika tidak ada flag

--- a/internal/services/crypto/text.go
+++ b/internal/services/crypto/text.go
@@ -9,10 +9,10 @@ import (
 	"sfDBTools/internal/services/crypto/helpers"
 	cryptomodel "sfDBTools/internal/services/crypto/model"
 	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/print"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/encrypt"
 	"sfDBTools/pkg/helper"
-	"sfDBTools/pkg/ui"
 )
 
 // ExecuteEncryptText menangani logic encrypt text
@@ -42,12 +42,12 @@ func ExecuteEncryptText(logger applog.Logger, opts cryptomodel.EncryptTextOption
 	if strings.TrimSpace(opts.OutputPath) == "" {
 		// Cetak base64 ke stdout
 		if !quiet {
-			ui.Headers("Encrypt Text")
-			ui.PrintSubHeader("Encrypted text output : ")
+			print.PrintAppHeader("Encrypt Text")
+			print.PrintSubHeader("Encrypted text output : ")
 		}
 		fmt.Println(base64.StdEncoding.EncodeToString(encBytes))
 		if !quiet {
-			ui.PrintDashedSeparator()
+			print.PrintDashedSeparator()
 		}
 		return nil
 	}
@@ -92,12 +92,12 @@ func ExecuteDecryptText(logger applog.Logger, opts cryptomodel.DecryptTextOption
 
 	if strings.TrimSpace(opts.OutputPath) == "" {
 		if !quiet {
-			ui.Headers("Decrypt Text")
-			ui.PrintSubHeader("Decrypted text output : ")
+			print.PrintAppHeader("Decrypt Text")
+			print.PrintSubHeader("Decrypted text output : ")
 		}
 		fmt.Println(string(plain))
 		if !quiet {
-			ui.PrintDashedSeparator()
+			print.PrintDashedSeparator()
 		}
 		return nil
 	}

--- a/internal/ui/doc.go
+++ b/internal/ui/doc.go
@@ -1,0 +1,14 @@
+// File : internal/ui/doc.go
+// Deskripsi : Package facade UI untuk seluruh aplikasi (pintu tunggal UI)
+// Author : Hadiyatna Muflihun
+// Tanggal : 5 Januari 2026
+// Last Modified : 5 Januari 2026
+
+// Package ui adalah entry point facade UI.
+//
+// NOTE: Pada PR UI-1, implementasi masih mendelegasikan ke legacy:
+// - sfDBTools/pkg/ui
+// - sfDBTools/pkg/input
+//
+// Package internal ini menjadi pintu tunggal UI untuk layer app/cli/services.
+package ui

--- a/internal/ui/print/print.go
+++ b/internal/ui/print/print.go
@@ -1,0 +1,67 @@
+// File : internal/ui/print/print.go
+// Deskripsi : Print helper (header/info/warn/error) untuk UI facade
+// Author : Hadiyatna Muflihun
+// Tanggal : 5 Januari 2026
+// Last Modified : 5 Januari 2026
+
+package print
+
+import (
+	"fmt"
+	"sfDBTools/internal/domain"
+	applog "sfDBTools/internal/services/log"
+	"sfDBTools/internal/ui/progress"
+	legacyui "sfDBTools/pkg/ui"
+)
+
+func PrintHeader(title string) {
+	legacyui.PrintHeader(title)
+}
+
+func PrintSubHeader(title string) {
+	legacyui.PrintSubHeader(title)
+}
+
+func PrintInfo(msg string) {
+	legacyui.PrintInfo(msg)
+}
+
+func PrintWarn(msg string) {
+	legacyui.PrintWarning(msg)
+}
+
+func PrintWarning(msg string) {
+	legacyui.PrintWarning(msg)
+}
+
+func PrintError(msg string) {
+	legacyui.PrintError(msg)
+}
+
+// PrintSuccess dipakai luas di codebase existing, jadi tetap disediakan sebagai facade.
+func PrintSuccess(msg string) {
+	legacyui.PrintSuccess(msg)
+}
+
+func PrintSeparator() {
+	legacyui.PrintSeparator()
+}
+
+func PrintDashedSeparator() {
+	legacyui.PrintDashedSeparator()
+}
+
+func PrintAppHeader(title string) {
+	legacyui.Headers(title)
+}
+
+func PrintFilterStats(stats *domain.FilterStats, context string, logger applog.Logger) {
+	legacyui.DisplayFilterStats(stats, context, logger)
+}
+
+// Println menambah satu baris kosong.
+func Println() {
+	progress.RunWithSpinnerSuspended(func() {
+		fmt.Println()
+	})
+}

--- a/internal/ui/progress/spinner.go
+++ b/internal/ui/progress/spinner.go
@@ -1,0 +1,85 @@
+// File : internal/ui/progress/spinner.go
+// Deskripsi : Spinner/progress untuk UI facade
+// Author : Hadiyatna Muflihun
+// Tanggal : 5 Januari 2026
+// Last Modified : 5 Januari 2026
+
+package progress
+
+import (
+	"fmt"
+	"os"
+	"sfDBTools/pkg/runtimecfg"
+	legacyui "sfDBTools/pkg/ui"
+	"time"
+
+	"github.com/briandowns/spinner"
+)
+
+// Spinner adalah wrapper spinner yang expose API sederhana.
+type Spinner struct {
+	noElapsed *spinner.Spinner
+	elapsed   *legacyui.SpinnerWithElapsed
+}
+
+// NewSpinner membuat spinner tanpa elapsed time.
+func NewSpinner(label string) *Spinner {
+	if runtimecfg.IsQuiet() || runtimecfg.IsDaemon() {
+		return &Spinner{}
+	}
+
+	sp := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	sp.Suffix = fmt.Sprintf(" %s...", label)
+	sp.Writer = os.Stderr
+
+	return &Spinner{noElapsed: sp}
+}
+
+// NewSpinnerWithElapsed membuat spinner dengan elapsed time tracking.
+func NewSpinnerWithElapsed(label string) *Spinner {
+	return &Spinner{elapsed: legacyui.NewSpinnerWithElapsed(label)}
+}
+
+func (s *Spinner) Start() {
+	if s == nil {
+		return
+	}
+	if s.elapsed != nil {
+		s.elapsed.Start()
+		return
+	}
+	if s.noElapsed != nil {
+		s.noElapsed.Start()
+	}
+}
+
+func (s *Spinner) Stop() {
+	if s == nil {
+		return
+	}
+	if s.elapsed != nil {
+		s.elapsed.Stop()
+		return
+	}
+	if s.noElapsed != nil {
+		s.noElapsed.Stop()
+	}
+}
+
+func (s *Spinner) Update(label string) {
+	if s == nil {
+		return
+	}
+	if s.elapsed != nil {
+		s.elapsed.UpdateMessage(label)
+		return
+	}
+	if s.noElapsed != nil {
+		s.noElapsed.Suffix = fmt.Sprintf(" %s...", label)
+	}
+}
+
+// RunWithSpinnerSuspended menjalankan action dengan spinner aktif (jika ada) disuspend.
+func RunWithSpinnerSuspended(action func()) {
+	legacyui.RunWithSpinnerSuspended(action)
+}

--- a/internal/ui/prompt/prompt.go
+++ b/internal/ui/prompt/prompt.go
@@ -1,0 +1,127 @@
+// File : internal/ui/prompt/prompt.go
+// Deskripsi : Prompt/input interaktif (select/confirm/password/text)
+// Author : Hadiyatna Muflihun
+// Tanggal : 5 Januari 2026
+// Last Modified : 5 Januari 2026
+
+package prompt
+
+import (
+	"fmt"
+	"sfDBTools/pkg/input"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+type textOptions struct {
+	defaultValue string
+	validator    survey.Validator
+}
+
+type TextOption func(*textOptions)
+
+func WithDefault(v string) TextOption {
+	return func(o *textOptions) { o.defaultValue = v }
+}
+
+func WithValidator(v survey.Validator) TextOption {
+	return func(o *textOptions) { o.validator = v }
+}
+
+func AskText(label string, opts ...TextOption) (string, error) {
+	cfg := &textOptions{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return input.AskString(label, cfg.defaultValue, cfg.validator)
+}
+
+func AskTicket(action string) (string, error) {
+	return input.AskTicket(action)
+}
+
+func ValidateFilename(ans interface{}) error {
+	return input.ValidateFilename(ans)
+}
+
+func ComposeValidators(validators ...survey.Validator) survey.Validator {
+	return input.ComposeValidators(validators...)
+}
+
+func AskPassword(label string, validator survey.Validator) (string, error) {
+	return input.AskPassword(label, validator)
+}
+
+func AskInt(label string, defaultValue int, validator survey.Validator) (int, error) {
+	return input.AskInt(label, defaultValue, validator)
+}
+
+func Confirm(label string, defaultYes bool) (bool, error) {
+	return input.AskYesNo(label, defaultYes)
+}
+
+func PromptPassword(message string) (string, error) {
+	return input.PromptPassword(message)
+}
+
+func PromptConfirm(message string) (bool, error) {
+	return input.PromptConfirm(message)
+}
+
+func SelectOne(label string, items []string, defaultIndex int) (string, int, error) {
+	if defaultIndex >= 0 && defaultIndex < len(items) {
+		selected, err := input.SelectSingleFromListWithDefault(items, label, items[defaultIndex])
+		if err != nil {
+			return "", -1, err
+		}
+		idx := indexOf(items, selected)
+		return selected, idx, nil
+	}
+	selected, err := input.SelectSingleFromList(items, label)
+	if err != nil {
+		return "", -1, err
+	}
+	idx := indexOf(items, selected)
+	return selected, idx, nil
+}
+
+func SelectMany(label string, items []string, defaults []int) ([]string, []int, error) {
+	_ = defaults
+	idxs1, err := input.ShowMultiSelect(label, items)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	selectedItems := make([]string, 0, len(idxs1))
+	selectedIdxs := make([]int, 0, len(idxs1))
+	for _, idx1 := range idxs1 {
+		idx := idx1 - 1
+		if idx >= 0 && idx < len(items) {
+			selectedItems = append(selectedItems, items[idx])
+			selectedIdxs = append(selectedIdxs, idx)
+		}
+	}
+	return selectedItems, selectedIdxs, nil
+}
+
+func SelectFile(directory string, label string, extensions []string) (string, error) {
+	return input.SelectFileInteractive(directory, label, extensions)
+}
+
+func WaitForEnter(message ...string) {
+	msg := "Tekan Enter untuk melanjutkan..."
+	if len(message) > 0 && message[0] != "" {
+		msg = message[0]
+	}
+	fmt.Print(msg)
+	_, _ = fmt.Scanln()
+}
+
+func indexOf(items []string, v string) int {
+	for i, s := range items {
+		if s == v {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/ui/style/colors.go
+++ b/internal/ui/style/colors.go
@@ -1,0 +1,24 @@
+// File : internal/ui/style/colors.go
+// Deskripsi : Konstanta style (warna/format) untuk UI facade
+// Author : Hadiyatna Muflihun
+// Tanggal : 5 Januari 2026
+// Last Modified : 5 Januari 2026
+
+package style
+
+import "sfDBTools/pkg/consts"
+
+// Color adalah alias string untuk warna/format ANSI.
+// Di fase UI-1, nilai ini masih memetakan ke konstanta legacy di pkg/consts.
+type Color = string
+
+const (
+	ColorReset  Color = consts.UIColorReset
+	ColorRed    Color = consts.UIColorRed
+	ColorGreen  Color = consts.UIColorGreen
+	ColorYellow Color = consts.UIColorYellow
+	ColorBlue   Color = consts.UIColorBlue
+	ColorCyan   Color = consts.UIColorCyan
+	ColorPurple Color = consts.UIColorPurple
+	ColorBold   Color = consts.UIColorBold
+)

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -1,0 +1,14 @@
+// File : internal/ui/table/table.go
+// Deskripsi : Renderer tabel untuk UI facade
+// Author : Hadiyatna Muflihun
+// Tanggal : 5 Januari 2026
+// Last Modified : 5 Januari 2026
+
+package table
+
+import legacyui "sfDBTools/pkg/ui"
+
+// Render merender tabel ke stdout.
+func Render(headers []string, rows [][]string) {
+	legacyui.FormatTable(headers, rows)
+}

--- a/internal/ui/text/text.go
+++ b/internal/ui/text/text.go
@@ -1,0 +1,24 @@
+// File : internal/ui/text/text.go
+// Deskripsi : Helper formatting text (warna, bold, dsb)
+// Author : Hadiyatna Muflihun
+// Tanggal : 5 Januari 2026
+// Last Modified : 5 Januari 2026
+
+package text
+
+import "sfDBTools/internal/ui/style"
+
+// Color memberi warna pada string.
+func Color(s string, color style.Color) string {
+	return string(color) + s + string(style.ColorReset)
+}
+
+// ColorText adalah alias kompatibilitas untuk Color.
+func ColorText(s string, color style.Color) string {
+	return Color(s, color)
+}
+
+// Bold membuat string menjadi bold.
+func Bold(s string) string {
+	return string(style.ColorBold) + s + string(style.ColorReset)
+}

--- a/main.go
+++ b/main.go
@@ -8,8 +8,9 @@ import (
 	"sfDBTools/internal/autoupdate"
 	appdeps "sfDBTools/internal/cli/deps"
 	config "sfDBTools/internal/services/config"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/progress"
 	"sfDBTools/pkg/runtimecfg"
-	"sfDBTools/pkg/ui"
 	"time"
 
 	applog "sfDBTools/internal/services/log"
@@ -50,9 +51,9 @@ func main() {
 		tmpLogger := applog.NewLogger(nil)
 
 		// Tampilkan spinner hanya jika auto-update aktif dan tidak dalam quiet/daemon.
-		var sp *ui.SpinnerWithElapsed
+		var sp *progress.Spinner
 		if autoupdate.AutoUpdateEnabled() && !(runtimecfg.IsQuiet() || runtimecfg.IsDaemon()) {
-			sp = ui.NewSpinnerWithElapsed("Cek update")
+			sp = progress.NewSpinnerWithElapsed("Cek update")
 			sp.Start()
 		}
 		if err := autoupdate.MaybeAutoUpdate(ctx, tmpLogger); err != nil {
@@ -65,7 +66,7 @@ func main() {
 	}
 
 	if !quiet {
-		ui.Headers("Main Menu")
+		print.PrintAppHeader("Main Menu")
 	}
 
 	// 1. Muat Konfigurasi (skip saat completion/version agar output bersih)

--- a/pkg/database/database_admin.go
+++ b/pkg/database/database_admin.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"sfDBTools/pkg/ui"
+	"sfDBTools/internal/ui/progress"
 )
 
 // CheckDatabaseExists mengecek apakah database sudah ada
@@ -33,7 +33,7 @@ func (c *Client) CheckDatabaseExists(ctx context.Context, dbName string) (bool, 
 
 // DropDatabase menghapus database
 func (c *Client) DropDatabase(ctx context.Context, dbName string) error {
-	spin := ui.NewSpinnerWithElapsed(fmt.Sprintf("Drop database %s", dbName))
+	spin := progress.NewSpinnerWithElapsed(fmt.Sprintf("Drop database %s", dbName))
 	spin.Start()
 	defer spin.Stop()
 

--- a/pkg/encrypt/encrypt_prompt.go
+++ b/pkg/encrypt/encrypt_prompt.go
@@ -2,7 +2,7 @@ package encrypt
 
 import (
 	"os"
-	"sfDBTools/pkg/input"
+	"sfDBTools/internal/ui/prompt"
 
 	"github.com/AlecAivazis/survey/v2"
 )
@@ -20,6 +20,6 @@ func PromptPassword(envVar, promptMsg string) (password, source string, err erro
 	if pw := os.Getenv(envVar); pw != "" {
 		return pw, "env", nil
 	}
-	pw, err := input.AskPassword(promptMsg, survey.Required)
+	pw, err := prompt.AskPassword(promptMsg, survey.Required)
 	return pw, "prompt", err
 }

--- a/pkg/helper/profile/profile_connection.go
+++ b/pkg/helper/profile/profile_connection.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/progress"
 	"sfDBTools/pkg/consts"
 	"sfDBTools/pkg/database"
 	"sfDBTools/pkg/process"
 	"sfDBTools/pkg/runtimecfg"
-	"sfDBTools/pkg/ui"
 )
 
 // EffectiveDBInfo mengembalikan DBInfo yang efektif untuk koneksi.
@@ -54,9 +54,9 @@ func ConnectWithProfile(profile *domain.ProfileInfo, initialDB string) (*databas
 		modeText = "melalui SSH Tunnel"
 	}
 
-	var spin *ui.SpinnerWithElapsed
+	var spin *progress.Spinner
 	if !quiet {
-		spin = ui.NewSpinnerWithElapsed(fmt.Sprintf("Menghubungkan ke %s %s", name, modeText))
+		spin = progress.NewSpinnerWithElapsed(fmt.Sprintf("Menghubungkan ke %s %s", name, modeText))
 		spin.Start()
 		defer spin.Stop()
 	}

--- a/pkg/helper/profile/profile_select.go
+++ b/pkg/helper/profile/profile_select.go
@@ -6,15 +6,15 @@ import (
 	"path/filepath"
 
 	"sfDBTools/internal/domain"
+	"sfDBTools/internal/ui/print"
+	"sfDBTools/internal/ui/prompt"
 	"sfDBTools/pkg/fsops"
 	"sfDBTools/pkg/helper/profileutil"
-	"sfDBTools/pkg/input"
-	"sfDBTools/pkg/ui"
 	"sfDBTools/pkg/validation"
 )
 
 func SelectExistingDBConfig(configDir, purpose string) (domain.ProfileInfo, error) {
-	ui.PrintSubHeader(purpose)
+	print.PrintSubHeader(purpose)
 
 	ProfileInfo := domain.ProfileInfo{}
 
@@ -31,20 +31,18 @@ func SelectExistingDBConfig(configDir, purpose string) (domain.ProfileInfo, erro
 	}
 
 	if len(filtered) == 0 {
-		ui.PrintWarning("Tidak ditemukan file konfigurasi di direktori: " + configDir)
-		ui.PrintInfo("Silakan buat file konfigurasi baru terlebih dahulu dengan perintah 'profile create'.")
+		print.PrintWarn("Tidak ditemukan file konfigurasi di direktori: " + configDir)
+		print.PrintInfo("Silakan buat file konfigurasi baru terlebih dahulu dengan perintah 'profile create'.")
 		return ProfileInfo, fmt.Errorf("tidak ada file konfigurasi untuk dipilih")
 	}
 
 	options := make([]string, 0, len(filtered))
 	options = append(options, filtered...)
 
-	idx, err := input.ShowMenu("Pilih file konfigurasi :", options)
+	selected, _, err := prompt.SelectOne("Pilih file konfigurasi :", options, 0)
 	if err != nil {
 		return ProfileInfo, validation.HandleInputError(err)
 	}
-
-	selected := options[idx-1]
 	name := profileutil.TrimProfileSuffix(selected)
 
 	filePath := filepath.Join(configDir, selected)


### PR DESCRIPTION
## Ringkasan
UI-1: memperkenalkan facade `internal/ui/*` sebagai satu-satunya gateway UI untuk code internal, sambil tetap *delegate* implementasi ke legacy `pkg/ui` + `pkg/input` (tanpa perubahan UX/behavior yang diharapkan).

## Perubahan Utama
- Tambah facade modular:
  - `internal/ui/print` (header/info/warn/error/success)
  - `internal/ui/prompt` (confirm/select/password/text + validator helpers)
  - `internal/ui/table` (render table)
  - `internal/ui/progress` (spinner)
  - `internal/ui/text`, `internal/ui/style`
- Migrasi call-sites: backup, cleanup, dbscan, crypto, profile, restore, jobs/cmd agar tidak import `sfDBTools/pkg/ui` / `sfDBTools/pkg/input` langsung.
- Import hygiene: `sfDBTools/pkg/ui` dan `sfDBTools/pkg/input` sekarang hanya muncul di `internal/ui/**`.

## Deprecation Plan
Ditulis di README pada bagian **Catatan Pengembang (UI Facade)**:
- UI-2: pindahkan implementasi UI dari `pkg/ui` / `pkg/input` ke `internal/ui/*` (facade berhenti sekadar delegasi)
- UI-3: tandai deprecated + phase-out pemakaian internal sepenuhnya

## Verifikasi
- `gofmt` pada area yang disentuh
- `go test ./...` (lulus)
