### PR TITLE
PR-v1.0.3-UI-2 — Move UI output ke internal/ui/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,12 +413,12 @@ sfdbtools <command> <subcommand> --help
 Mulai UI-1, seluruh code internal wajib lewat facade `internal/ui/*`:
 
 - Gunakan `internal/ui/print`, `internal/ui/prompt`, `internal/ui/table`, `internal/ui/progress`, `internal/ui/text`, `internal/ui/style`.
-- Package legacy `pkg/ui` dan `pkg/input` hanya boleh di-import oleh facade `internal/ui/*`.
+- Per UI-2, implementasi UI output sudah berada di `internal/ui/*` (tidak ada lagi pemakaian paket UI legacy).
+- Legacy yang masih tersisa hanya `pkg/input` untuk prompt (akan ditangani di UI-3).
 
 Rencana deprecation bertahap:
 
-- UI-2: pindahkan implementasi UI dari `pkg/ui` / `pkg/input` ke `internal/ui/*` (tanpa mengubah UX), facade tidak lagi sekadar delegasi.
-- UI-3: tandai `pkg/ui` / `pkg/input` sebagai deprecated (doc + lint/CI), lalu phase-out pemakaian internal sepenuhnya.
+- UI-3: pindahkan prompt/validator dari `pkg/input` ke `internal/ui/prompt`, lalu tandai `pkg/input` sebagai deprecated (doc + lint/CI) dan phase-out pemakaian internal sepenuhnya.
 
 ## Lisensi
 

--- a/internal/app/dbscan/display.go
+++ b/internal/app/dbscan/display.go
@@ -49,7 +49,7 @@ func (s *Service) DisplayScanOptions() (bool, error) {
 	return true, nil
 }
 
-// Wrapper methods for pkg/dbscanhelper and pkg/ui display functions
+// Wrapper methods untuk helper display
 
 func (s *Service) DisplayFilterStats(stats *domain.FilterStats) {
 	print.PrintFilterStats(stats, "scan", s.Log)

--- a/internal/ui/doc.go
+++ b/internal/ui/doc.go
@@ -7,7 +7,6 @@
 // Package ui adalah entry point facade UI.
 //
 // NOTE: Pada PR UI-1, implementasi masih mendelegasikan ke legacy:
-// - sfDBTools/pkg/ui
 // - sfDBTools/pkg/input
 //
 // Package internal ini menjadi pintu tunggal UI untuk layer app/cli/services.

--- a/internal/ui/print/filter_stats.go
+++ b/internal/ui/print/filter_stats.go
@@ -1,16 +1,25 @@
-package ui
+// File : internal/ui/print/filter_stats.go
+// Deskripsi : Tampilkan statistik filtering database (UI output)
+// Author : Hadiyatna Muflihun
+// Tanggal : 11 November 2025
+// Last Modified : 5 Januari 2026
+
+package print
 
 import (
 	"fmt"
 	"sfDBTools/internal/domain"
-	applog "sfDBTools/internal/services/log"
-	"sfDBTools/pkg/consts"
+	"sfDBTools/internal/ui/style"
+	"sfDBTools/internal/ui/table"
+	"sfDBTools/internal/ui/text"
+
+	"github.com/sirupsen/logrus"
 )
 
 // DisplayFilterStats menampilkan statistik hasil pemfilteran database secara reusable.
 // Context parameter untuk menyesuaikan label (contoh: "Akan di-backup" atau "Akan di-scan")
 // Logger parameter opsional untuk logging (bisa nil)
-func DisplayFilterStats(stats *domain.FilterStats, konteks string, logger applog.Logger) {
+func PrintFilterStats(stats *domain.FilterStats, konteks string, logger logrus.FieldLogger) {
 	PrintSubHeader("Statistik Filtering Database")
 
 	// Hitung total excluded
@@ -26,7 +35,7 @@ func DisplayFilterStats(stats *domain.FilterStats, konteks string, logger applog
 
 	// Log statistik filtering
 	if logger != nil {
-		logger.WithFields(map[string]interface{}{
+		logger.WithFields(logrus.Fields{
 			"context":          konteks,
 			"total_found":      stats.TotalFound,
 			"total_included":   stats.TotalIncluded,
@@ -40,14 +49,14 @@ func DisplayFilterStats(stats *domain.FilterStats, konteks string, logger applog
 
 	data := [][]string{
 		{"Total Ditemukan", fmt.Sprintf("%d", stats.TotalFound)},
-		{actionLabel, ColorText(fmt.Sprintf("%d", stats.TotalIncluded), consts.UIColorGreen)},
-		{"Total Dikecualikan", ColorText(fmt.Sprintf("%d", totalExcluded), consts.UIColorYellow)},
+		{actionLabel, text.Color(fmt.Sprintf("%d", stats.TotalIncluded), style.ColorGreen)},
+		{"Total Dikecualikan", text.Color(fmt.Sprintf("%d", totalExcluded), style.ColorYellow)},
 	}
 
 	// Tampilkan detail exclusion jika ada yang dikecualikan
 	if totalExcluded > 0 {
 		data = append(data, []string{"", ""}) // Empty row for separation
-		data = append(data, []string{ColorText("Detail Exclusion:", consts.UIColorCyan), ""})
+		data = append(data, []string{text.Color("Detail Exclusion:", style.ColorCyan), ""})
 
 		if stats.ExcludedSystem > 0 {
 			data = append(data, []string{"  - Sistem Database", fmt.Sprintf("%d", stats.ExcludedSystem)})
@@ -63,7 +72,7 @@ func DisplayFilterStats(stats *domain.FilterStats, konteks string, logger applog
 		}
 	}
 
-	FormatTable([]string{"Kategori", "Jumlah"}, data)
+	table.Render([]string{"Kategori", "Jumlah"}, data)
 
 	// Tampilkan warning untuk database yang tidak ditemukan di server
 	hasWarnings := len(stats.NotFoundInInclude) > 0 || len(stats.NotFoundInExclude) > 0 || len(stats.NotFoundInWhitelist) > 0 || len(stats.NotFoundInBlacklist) > 0
@@ -73,7 +82,7 @@ func DisplayFilterStats(stats *domain.FilterStats, konteks string, logger applog
 
 		// Log warning tentang database tidak ditemukan
 		if logger != nil {
-			logger.WithFields(map[string]interface{}{
+			logger.WithFields(logrus.Fields{
 				"not_found_in_include":   stats.NotFoundInInclude,
 				"not_found_in_exclude":   stats.NotFoundInExclude,
 				"not_found_in_whitelist": stats.NotFoundInWhitelist,

--- a/internal/ui/print/formatting.go
+++ b/internal/ui/print/formatting.go
@@ -1,45 +1,40 @@
-// File : pkg/ui/ui_formatting.go
+// File : internal/ui/print/formatting.go
 // Deskripsi : Fungsi utilitas untuk output format di terminal
 // Author : Hadiyatna Muflihun
 // Tanggal : 3 Oktober 2024
-// Last Modified : 4 Januari 2026
-package ui
+// Last Modified : 5 Januari 2026
+
+package print
 
 import (
 	"fmt"
-	"os"
-	"sfDBTools/pkg/consts"
+	"sfDBTools/internal/ui/progress"
+	"sfDBTools/internal/ui/style"
+	"sfDBTools/internal/ui/text"
 	"sfDBTools/pkg/runtimecfg"
 	"strings"
-
-	"github.com/olekukonko/tablewriter"
 )
 
-// ColorText applies color to text
-func ColorText(text, color string) string {
-	return color + text + consts.UIColorReset
-}
-
 // PrintColoredLine prints a line with the specified color
-func PrintColoredLine(text, color string) {
-	RunWithSpinnerSuspended(func() {
-		fmt.Println(ColorText(text, color))
+func PrintColoredLine(msg string, color style.Color) {
+	progress.RunWithSpinnerSuspended(func() {
+		fmt.Println(text.Color(msg, color))
 	})
 }
 
 // PrintSuccess prints success message in green
 func PrintSuccess(message string) {
-	PrintColoredLine("✅ "+message, consts.UIColorGreen)
+	PrintColoredLine("✅ "+message, style.ColorGreen)
 }
 
 // PrintWarning prints warning message in yellow
 func PrintWarning(message string) {
-	PrintColoredLine(message, consts.UIColorYellow)
+	PrintColoredLine(message, style.ColorYellow)
 }
 
 // PrintInfo prints info message in blue
 func PrintInfo(message string) {
-	PrintColoredLine(message, consts.UIColorBlue)
+	PrintColoredLine(message, style.ColorBlue)
 }
 
 // PrintHeader prints a header with border
@@ -65,15 +60,15 @@ func PrintHeader(title string) {
 	rightPad := strings.Repeat(" ", width-titleLen-2-padding)
 
 	fmt.Println()
-	PrintColoredLine(border, consts.UIColorCyan)
-	PrintColoredLine("|"+leftPad+title+rightPad+"|", consts.UIColorCyan)
-	PrintColoredLine(border, consts.UIColorCyan)
+	PrintColoredLine(border, style.ColorCyan)
+	PrintColoredLine("|"+leftPad+title+rightPad+"|", style.ColorCyan)
+	PrintColoredLine(border, style.ColorCyan)
 	fmt.Println()
 }
 
 // PrintError prints error message in red
 func PrintError(message string) {
-	PrintColoredLine("❌ "+message, consts.UIColorRed)
+	PrintColoredLine("❌ "+message, style.ColorRed)
 }
 
 // PrintSubHeader prints a sub-header
@@ -83,23 +78,11 @@ func PrintSubHeader(title string) {
 	}
 
 	fmt.Println()
-	PrintColoredLine("📋 "+title, consts.UIColorBold)
+	PrintColoredLine("📋 "+title, style.ColorBold)
 	PrintDashedSeparator()
 }
 
-// FormatTable formats data as a table using tablewriter library for better appearance
-func FormatTable(headers []string, rows [][]string) {
-	if len(headers) == 0 || len(rows) == 0 {
-		return
-	}
-
-	table := tablewriter.NewWriter(os.Stdout)
-
-	// Set table headers using the correct method
-	table.Header(headers)
-
-	table.Bulk(rows)
-
-	// Render the table
-	table.Render()
+// PrintWarn adalah alias kompatibilitas untuk PrintWarning.
+func PrintWarn(message string) {
+	PrintWarning(message)
 }

--- a/internal/ui/print/print.go
+++ b/internal/ui/print/print.go
@@ -8,56 +8,8 @@ package print
 
 import (
 	"fmt"
-	"sfDBTools/internal/domain"
-	applog "sfDBTools/internal/services/log"
 	"sfDBTools/internal/ui/progress"
-	legacyui "sfDBTools/pkg/ui"
 )
-
-func PrintHeader(title string) {
-	legacyui.PrintHeader(title)
-}
-
-func PrintSubHeader(title string) {
-	legacyui.PrintSubHeader(title)
-}
-
-func PrintInfo(msg string) {
-	legacyui.PrintInfo(msg)
-}
-
-func PrintWarn(msg string) {
-	legacyui.PrintWarning(msg)
-}
-
-func PrintWarning(msg string) {
-	legacyui.PrintWarning(msg)
-}
-
-func PrintError(msg string) {
-	legacyui.PrintError(msg)
-}
-
-// PrintSuccess dipakai luas di codebase existing, jadi tetap disediakan sebagai facade.
-func PrintSuccess(msg string) {
-	legacyui.PrintSuccess(msg)
-}
-
-func PrintSeparator() {
-	legacyui.PrintSeparator()
-}
-
-func PrintDashedSeparator() {
-	legacyui.PrintDashedSeparator()
-}
-
-func PrintAppHeader(title string) {
-	legacyui.Headers(title)
-}
-
-func PrintFilterStats(stats *domain.FilterStats, context string, logger applog.Logger) {
-	legacyui.DisplayFilterStats(stats, context, logger)
-}
 
 // Println menambah satu baris kosong.
 func Println() {

--- a/internal/ui/print/terminal.go
+++ b/internal/ui/print/terminal.go
@@ -1,10 +1,17 @@
-package ui
+// File : internal/ui/print/terminal.go
+// Deskripsi : Helper terminal (size, separator, wait)
+// Author : Hadiyatna Muflihun
+// Tanggal : 3 Oktober 2024
+// Last Modified : 5 Januari 2026
+
+package print
 
 import (
 	"fmt"
 	"os"
 	"os/exec"
 	"runtime"
+	"sfDBTools/internal/ui/progress"
 	"strings"
 )
 
@@ -59,7 +66,9 @@ func PrintBorder(char rune, width int) {
 	}
 
 	border := strings.Repeat(string(char), width)
-	fmt.Println(border)
+	progress.RunWithSpinnerSuspended(func() {
+		fmt.Println(border)
+	})
 }
 
 // PrintSeparator prints a separator line

--- a/internal/ui/progress/spinner.go
+++ b/internal/ui/progress/spinner.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"sfDBTools/pkg/runtimecfg"
-	legacyui "sfDBTools/pkg/ui"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -19,7 +18,7 @@ import (
 // Spinner adalah wrapper spinner yang expose API sederhana.
 type Spinner struct {
 	noElapsed *spinner.Spinner
-	elapsed   *legacyui.SpinnerWithElapsed
+	elapsed   *elapsedSpinner
 }
 
 // NewSpinner membuat spinner tanpa elapsed time.
@@ -37,7 +36,7 @@ func NewSpinner(label string) *Spinner {
 
 // NewSpinnerWithElapsed membuat spinner dengan elapsed time tracking.
 func NewSpinnerWithElapsed(label string) *Spinner {
-	return &Spinner{elapsed: legacyui.NewSpinnerWithElapsed(label)}
+	return &Spinner{elapsed: newElapsedSpinner(label)}
 }
 
 func (s *Spinner) Start() {
@@ -77,9 +76,4 @@ func (s *Spinner) Update(label string) {
 	if s.noElapsed != nil {
 		s.noElapsed.Suffix = fmt.Sprintf(" %s...", label)
 	}
-}
-
-// RunWithSpinnerSuspended menjalankan action dengan spinner aktif (jika ada) disuspend.
-func RunWithSpinnerSuspended(action func()) {
-	legacyui.RunWithSpinnerSuspended(action)
 }

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -6,9 +6,20 @@
 
 package table
 
-import legacyui "sfDBTools/pkg/ui"
+import (
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+)
 
 // Render merender tabel ke stdout.
 func Render(headers []string, rows [][]string) {
-	legacyui.FormatTable(headers, rows)
+	if len(headers) == 0 || len(rows) == 0 {
+		return
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.Header(headers)
+	table.Bulk(rows)
+	table.Render()
 }


### PR DESCRIPTION
## Ringkasan
UI-2: memindahkan implementasi UI output dari paket legacy ke `internal/ui/*` (print/table/progress/text/style). PR ini **tidak** menyentuh prompt/validator legacy (itu UI-3).

## Perubahan Utama
- `pkg/ui/*` dipindahkan (git mv) ke:
  - `internal/ui/print/*` (printing, header, terminal helpers, filter stats)
  - `internal/ui/progress/*` (elapsed spinner + spinner suspension)
  - `internal/ui/table/*` (table render via tablewriter)
- Facade `internal/ui/*` tidak lagi meng-import paket UI legacy untuk output.
- Repo-wide import hygiene: `sfDBTools/pkg/ui` sekarang 0 pemakaian (code).

## Catatan
- `PrintAppHeader` sekarang membentuk judul memakai `pkg/version.Version` (tanpa load config) dan tetap menjaga behavior clear screen hanya saat stdout TTY.

## Verifikasi
- `gofmt` pada file yang disentuh
- `go test ./...` (lulus)
