### PR TITLE
refactor(sanitize): move argument sanitization to a dedicated package

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	scriptcmd "sfdbtools/cmd/script"
 	appdeps "sfdbtools/internal/cli/deps"
 	"sfdbtools/internal/shared/runtimecfg"
+	"sfdbtools/internal/shared/sanitize"
 	"sfdbtools/internal/ui/print"
 	"strings"
 
@@ -60,7 +61,7 @@ Didesain untuk keandalan dan penggunaan di lingkungan produksi.`,
 
 		// Log bahwa perintah akan dieksekusi, termasuk argumen (tanpa membocorkan secret).
 		bin := filepath.Base(os.Args[0])
-		argsSafe := sanitizeArgs(os.Args[1:])
+		argsSafe := sanitize.Args(os.Args[1:])
 		argLine := strings.Join(argsSafe, " ")
 		if strings.TrimSpace(argLine) == "" {
 			argLine = "-"

--- a/internal/shared/sanitize/args.go
+++ b/internal/shared/sanitize/args.go
@@ -1,20 +1,18 @@
-// File : cmd/args_sanitize.go
+// File : internal/shared/sanitize/args.go
 // Deskripsi : Sanitizer argumen CLI untuk logging (masking nilai sensitif)
 // Author : Hadiyatna Muflihun
-// Tanggal : 2 Januari 2026
-// Last Modified : 2 Januari 2026
+// Tanggal : 13 Januari 2026
+// Last Modified : 13 Januari 2026
 
-package cmd
+package sanitize
 
-import (
-	"strings"
-)
+import "strings"
 
 const maskedValue = "******"
 
-// sanitizeArgs mengembalikan salinan args dengan nilai sensitif dimasking.
+// Args mengembalikan salinan args dengan nilai sensitif dimasking.
 // Tujuan: argumen bisa dicatat di log tanpa membocorkan password/key/token.
-func sanitizeArgs(args []string) []string {
+func Args(args []string) []string {
 	out := make([]string, 0, len(args))
 	maskNext := false
 


### PR DESCRIPTION
This pull request refactors the argument sanitization logic to improve code organization and clarity. The main change is moving the argument sanitization function to a new package and updating its usage throughout the codebase.

Refactoring and code organization:

* Moved the argument sanitization logic from `cmd/args_sanitize.go` to `internal/shared/sanitize/args.go`, renaming the function from `sanitizeArgs` to `Args` and changing its package from `cmd` to `sanitize`.
* Updated imports in `cmd/root.go` to use the new `sanitize` package for argument sanitization.
* Updated the call site in `cmd/root.go` to use `sanitize.Args` instead of the old `sanitizeArgs` function.