### PR TITLE
profile: thin service orchestration + DRY retry + ISP ops split

### DIFF
--- a/internal/app/profile/executor/edit.go
+++ b/internal/app/profile/executor/edit.go
@@ -123,17 +123,15 @@ func (e *Executor) EditProfile() error {
 		}
 
 		if err := e.SaveProfile(consts.ProfileSaveModeEdit); err != nil {
-			if err == validation.ErrConnectionFailedRetry {
-				retry, err2 := e.handleConnectionFailedRetry(consts.ProfileMsgRetryEdit, consts.ProfileMsgEditCancelled)
-				if err2 != nil {
-					return err2
-				}
-				if retry {
-					continue
-				}
-				return validation.ErrUserCancelled
+			retry, err2 := e.handleConnectionFailedRetryIfNeeded(err, consts.ProfileMsgRetryEdit, consts.ProfileMsgEditCancelled)
+			if err2 != nil {
+				return err2
 			}
-			return err
+			if retry {
+				continue
+			}
+			// Defensive: seharusnya tidak pernah sampai sini (cancel return error).
+			return validation.ErrUserCancelled
 		}
 		break
 	}

--- a/internal/app/profile/executor/executor.go
+++ b/internal/app/profile/executor/executor.go
@@ -21,13 +21,46 @@ import (
 )
 
 // ProfileOps defines minimal operations needed by executor
-type ProfileOps interface {
+
+// WizardProvider menyediakan runner untuk wizard.
+type WizardProvider interface {
 	NewWizard() *wizard.Runner
+}
+
+// ProfileSaver menyimpan profile state ke file.
+type ProfileSaver interface {
 	SaveProfile(mode string) error
+}
+
+// NameUniquenessChecker memvalidasi nama profile unik.
+type NameUniquenessChecker interface {
 	CheckConfigurationNameUnique(mode string) error
+}
+
+// SnapshotLoader memuat snapshot dari file profile.
+type SnapshotLoader interface {
 	LoadSnapshotFromPath(absPath string) (*domain.ProfileInfo, error)
+}
+
+// ExistingConfigSelector menangani pemilihan profile existing secara interaktif.
+type ExistingConfigSelector interface {
 	PromptSelectExistingConfig() error
+}
+
+// ConfigFormatter mengubah state profile menjadi format INI.
+type ConfigFormatter interface {
 	FormatConfigToINI() string
+}
+
+// ProfileOps adalah composite interface untuk kebutuhan Executor saat ini.
+// Catatan: Executor methods idealnya hanya bergantung pada sub-interface yang dibutuhkan.
+type ProfileOps interface {
+	WizardProvider
+	ProfileSaver
+	NameUniquenessChecker
+	SnapshotLoader
+	ExistingConfigSelector
+	ConfigFormatter
 }
 
 type Executor struct {

--- a/internal/app/profile/executor/retry_helper.go
+++ b/internal/app/profile/executor/retry_helper.go
@@ -2,7 +2,7 @@
 // Deskripsi : Helper DRY untuk flow retry saat koneksi DB gagal ketika save profile
 // Author : Hadiyatna Muflihun
 // Tanggal : 4 Januari 2026
-// Last Modified : 4 Januari 2026
+// Last Modified : 14 Januari 2026
 
 package executor
 
@@ -24,4 +24,23 @@ func (e *Executor) handleConnectionFailedRetry(retryWarningMsg string, cancelInf
 	}
 	print.PrintInfo(cancelInfoMsg)
 	return false, validation.ErrUserCancelled
+}
+
+// handleConnectionFailedRetryIfNeeded memusatkan flow retry untuk error koneksi DB.
+// Return:
+// - shouldRetry=true  => caller bisa `continue`
+// - err!=nil          => error final (termasuk ErrUserCancelled)
+func (e *Executor) handleConnectionFailedRetryIfNeeded(opErr error, retryWarningMsg string, cancelInfoMsg string) (shouldRetry bool, err error) {
+	if opErr == nil {
+		return false, nil
+	}
+	if opErr != validation.ErrConnectionFailedRetry {
+		return false, opErr
+	}
+
+	retry, err := e.handleConnectionFailedRetry(retryWarningMsg, cancelInfoMsg)
+	if err != nil {
+		return false, err
+	}
+	return retry, nil
 }

--- a/internal/app/profile/executor_ops.go
+++ b/internal/app/profile/executor_ops.go
@@ -1,0 +1,73 @@
+// File : internal/app/profile/executor_ops.go
+// Deskripsi : Adapter ops untuk Executor agar Service tetap tipis (thin orchestrator)
+// Author : Hadiyatna Muflihun
+// Tanggal : 14 Januari 2026
+// Last Modified : 14 Januari 2026
+
+package profile
+
+import (
+	"sfdbtools/internal/app/profile/executor"
+	profilemodel "sfdbtools/internal/app/profile/model"
+	"sfdbtools/internal/app/profile/wizard"
+	"sfdbtools/internal/domain"
+	appconfig "sfdbtools/internal/services/config"
+	applog "sfdbtools/internal/services/log"
+)
+
+// executorOps mengenkapsulasi operasi yang dibutuhkan oleh package executor.
+// Tujuan: mengurangi jumlah method di Service (thin orchestrator) tanpa mengubah behavior.
+//
+// Catatan: Ini sengaja membungkus state pointer agar executor/wizard tetap jadi single source of truth.
+type executorOps struct {
+	Config *appconfig.Config
+	Log    applog.Logger
+	State  *profilemodel.ProfileState
+}
+
+func newExecutorOps(cfg *appconfig.Config, log applog.Logger, state *profilemodel.ProfileState) *executorOps {
+	return &executorOps{Config: cfg, Log: log, State: state}
+}
+
+func (s *executorOps) configDir() string {
+	if s == nil || s.Config == nil {
+		return ""
+	}
+	return s.Config.ConfigDir.DatabaseProfile
+}
+
+// =============================================================================
+// Implementasi executor.ProfileOps (adapter)
+// =============================================================================
+
+func (s *executorOps) NewWizard() *wizard.Runner {
+	return wizard.New(
+		s.Log,
+		s.configDir(),
+		s.State,
+		s.CheckConfigurationNameUnique,
+		s.LoadSnapshotFromPath,
+	)
+}
+
+func (s *executorOps) SaveProfile(mode string) error {
+	e := executor.New(s.Log, s.configDir(), s.State, s)
+	return e.SaveProfile(mode)
+}
+
+func (s *executorOps) CheckConfigurationNameUnique(mode string) error {
+	return s.checkConfigurationNameUnique(mode)
+}
+
+func (s *executorOps) LoadSnapshotFromPath(absPath string) (*domain.ProfileInfo, error) {
+	err := s.loadSnapshotFromPath(absPath)
+	return s.State.OriginalProfileInfo, err
+}
+
+func (s *executorOps) PromptSelectExistingConfig() error {
+	return s.promptSelectExistingConfig()
+}
+
+func (s *executorOps) FormatConfigToINI() string {
+	return s.formatConfigToINI()
+}

--- a/internal/app/profile/profile_validation.go
+++ b/internal/app/profile/profile_validation.go
@@ -2,7 +2,7 @@
 // Deskripsi : Validasi dan pengecekan unik untuk profile
 // Author : Hadiyatna Muflihun
 // Tanggal : 4 Januari 2026
-// Last Modified : 6 Januari 2026
+// Last Modified : 14 Januari 2026
 package profile
 
 import (
@@ -61,7 +61,7 @@ func deriveOriginalProfileName(originalProfileName string, profileInfo *domain.P
 }
 
 // CheckConfigurationNameUnique memvalidasi apakah nama konfigurasi unik.
-func (s *Service) checkConfigurationNameUnique(mode string) error {
+func (s *executorOps) checkConfigurationNameUnique(mode string) error {
 	if s.State.ProfileInfo == nil {
 		return shared.ErrProfileNil
 	}

--- a/internal/app/profile/select_existing.go
+++ b/internal/app/profile/select_existing.go
@@ -2,7 +2,7 @@
 // Deskripsi : Pemilihan profile secara interaktif (shared untuk show/edit)
 // Author : Hadiyatna Muflihun
 // Tanggal : 4 Januari 2026
-// Last Modified : 5 Januari 2026
+// Last Modified : 14 Januari 2026
 
 package profile
 
@@ -12,7 +12,7 @@ import (
 	"sfdbtools/internal/shared/consts"
 )
 
-func (s *Service) promptSelectExistingConfig() error {
+func (s *executorOps) promptSelectExistingConfig() error {
 	info, originalName, snapshot, err := profilehelper.SelectExistingDBConfigWithSnapshot(
 		s.Config.ConfigDir.DatabaseProfile,
 		consts.ProfileWizardPromptSelectExistingConfig,

--- a/internal/app/profile/service_methods.go
+++ b/internal/app/profile/service_methods.go
@@ -8,73 +8,32 @@ package profile
 
 import (
 	"sfdbtools/internal/app/profile/executor"
-	"sfdbtools/internal/app/profile/wizard"
-	"sfdbtools/internal/domain"
 )
-
-// Service implements executor.ProfileOps interface
-var _ executor.ProfileOps = (*Service)(nil)
 
 // CreateProfile creates a new profile
 func (s *Service) CreateProfile() error {
-	e := executor.New(s.Log, s.Config.ConfigDir.DatabaseProfile, s.State, s)
+	ops := newExecutorOps(s.Config, s.Log, s.State)
+	e := executor.New(s.Log, ops.configDir(), s.State, ops)
 	return e.CreateProfile()
 }
 
 // EditProfile edits an existing profile
 func (s *Service) EditProfile() error {
-	e := executor.New(s.Log, s.Config.ConfigDir.DatabaseProfile, s.State, s)
+	ops := newExecutorOps(s.Config, s.Log, s.State)
+	e := executor.New(s.Log, ops.configDir(), s.State, ops)
 	return e.EditProfile()
 }
 
 // ShowProfile shows profile details
 func (s *Service) ShowProfile() error {
-	e := executor.New(s.Log, s.Config.ConfigDir.DatabaseProfile, s.State, s)
+	ops := newExecutorOps(s.Config, s.Log, s.State)
+	e := executor.New(s.Log, ops.configDir(), s.State, ops)
 	return e.ShowProfile()
 }
 
 // PromptDeleteProfile deletes a profile
 func (s *Service) PromptDeleteProfile() error {
-	e := executor.New(s.Log, s.Config.ConfigDir.DatabaseProfile, s.State, s)
+	ops := newExecutorOps(s.Config, s.Log, s.State)
+	e := executor.New(s.Log, ops.configDir(), s.State, ops)
 	return e.PromptDeleteProfile()
-}
-
-// SaveProfile saves current profile state
-func (s *Service) SaveProfile(mode string) error {
-	e := executor.New(s.Log, s.Config.ConfigDir.DatabaseProfile, s.State, s)
-	return e.SaveProfile(mode)
-}
-
-// ProfileOps interface implementations
-
-// NewWizard creates a new wizard runner
-func (s *Service) NewWizard() *wizard.Runner {
-	return wizard.New(
-		s.Log,
-		s.Config.ConfigDir.DatabaseProfile,
-		s.State,
-		s.CheckConfigurationNameUnique,
-		s.LoadSnapshotFromPath,
-	)
-}
-
-// CheckConfigurationNameUnique checks if configuration name is unique
-func (s *Service) CheckConfigurationNameUnique(mode string) error {
-	return s.checkConfigurationNameUnique(mode)
-}
-
-// LoadSnapshotFromPath loads profile snapshot from path
-func (s *Service) LoadSnapshotFromPath(absPath string) (*domain.ProfileInfo, error) {
-	err := s.loadSnapshotFromPath(absPath)
-	return s.State.OriginalProfileInfo, err
-}
-
-// PromptSelectExistingConfig prompts user to select existing config
-func (s *Service) PromptSelectExistingConfig() error {
-	return s.promptSelectExistingConfig()
-}
-
-// FormatConfigToINI formats config to INI string
-func (s *Service) FormatConfigToINI() string {
-	return s.formatConfigToINI()
 }

--- a/internal/app/profile/setup.go
+++ b/internal/app/profile/setup.go
@@ -14,13 +14,13 @@ import (
 )
 
 // filePathInConfigDir membangun absolute path di dalam config dir untuk nama file konfigurasi yang diberikan.
-func (s *Service) filePathInConfigDir(name string) string {
+func (s *executorOps) filePathInConfigDir(name string) string {
 	cfgDir := s.Config.ConfigDir.DatabaseProfile
 	return filepath.Join(cfgDir, shared.BuildProfileFileName(name))
 }
 
 // loadSnapshotFromPath membaca file terenkripsi, mencoba dekripsi, parse, dan mengisi OriginalProfileInfo.
-func (s *Service) loadSnapshotFromPath(absPath string) error {
+func (s *executorOps) loadSnapshotFromPath(absPath string) error {
 	key := ""
 	if s.State.ProfileInfo != nil {
 		key = s.State.ProfileInfo.EncryptionKey
@@ -40,7 +40,7 @@ func (s *Service) loadSnapshotFromPath(absPath string) error {
 }
 
 // formatConfigToINI mengubah struct DBConfigInfo menjadi format string INI.
-func (s *Service) formatConfigToINI() string {
+func (s *executorOps) formatConfigToINI() string {
 	// [client] adalah header standar untuk file my.cnf
 	content := `[client]
 host=%s


### PR DESCRIPTION
- Add executorOps adapter to decouple Service from executor ops
- Centralize save retry handling for create/edit
- Split executor.ProfileOps into small sub-interfaces (composite preserved)
- go test [NFS](http://_vscodecontentref_/2).