### PR TITLE
refactor(backup): apply production-grade fixes and optimizations

### DIFF
--- a/.omg/state/learn-watch.json
+++ b/.omg/state/learn-watch.json
@@ -1,6 +1,6 @@
 {
-  "last_session_id": "a1e53197-8618-4d65-ad59-07833a7fc4b9",
-  "last_event_key": "a1e53197-8618-4d65-ad59-07833a7fc4b9:transcript:90753778f66d6b3937eeba738b181d01b745f022d9e76a6089271d031aa9215a",
+  "last_session_id": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf",
+  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
   "last_prompted_session_id": "a1e53197-8618-4d65-ad59-07833a7fc4b9",
   "last_reason": "short-session",
   "last_prompted_at": "2026-04-23T03:46:51.329Z",
@@ -8,5 +8,5 @@
   "last_actionable_message_count": 0,
   "deep_interview_lock_active": false,
   "deep_interview_lock_source": "/home/dbado/sfDBTools/.omg/state/deep-interview.json",
-  "updated_at": "2026-04-23T09:57:28.519Z"
+  "updated_at": "2026-04-24T06:37:01.211Z"
 }

--- a/.omg/state/quota-watch.json
+++ b/.omg/state/quota-watch.json
@@ -1,9 +1,9 @@
 {
-  "turn_count": 28,
-  "last_session_id": "a1e53197-8618-4d65-ad59-07833a7fc4b9",
-  "last_event_key": "a1e53197-8618-4d65-ad59-07833a7fc4b9:transcript:90753778f66d6b3937eeba738b181d01b745f022d9e76a6089271d031aa9215a",
-  "last_transcript_hash": "90753778f66d6b3937eeba738b181d01b745f022d9e76a6089271d031aa9215a",
+  "turn_count": 0,
+  "last_session_id": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf",
+  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
+  "last_transcript_hash": "c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
   "cwd_mode": "parent-leaf",
   "last_cwd_label": "dbado/sfDBTools",
-  "updated_at": "2026-04-23T09:57:28.559Z"
+  "updated_at": "2026-04-24T06:37:01.286Z"
 }

--- a/internal/app/backup/bridges.go
+++ b/internal/app/backup/bridges.go
@@ -36,7 +36,7 @@ func (s *Service) handleSingleModeSetup(ctx context.Context, client interface {
 // =============================================================================
 
 func (s *Service) SetupBackupExecution(state *BackupExecutionState) error {
-	return setup.New(s.Log, s.Config, s.BackupDBOptions, &state.ExcludedDatabases).SetupBackupExecution()
+	return setup.New(s.Log, s.Config, s.BackupDBOptions, state).SetupBackupExecution()
 }
 
 // PrepareBackupSession bridge to setup.PrepareBackupSession.
@@ -48,7 +48,7 @@ func (s *Service) PrepareBackupSession(ctx context.Context, state *BackupExecuti
 	pathGenerator := func(ctx context.Context, client *database.Client, dbFiltered []string) ([]string, error) {
 		return s.GenerateBackupPaths(ctx, state, client, dbFiltered)
 	}
-	return setup.New(s.Log, s.Config, s.BackupDBOptions, &state.ExcludedDatabases).
+	return setup.New(s.Log, s.Config, s.BackupDBOptions, state).
 		PrepareBackupSession(ctx, headerTitle, nonInteractive, pathGenerator)
 }
 

--- a/internal/app/backup/cleanup_critical.go
+++ b/internal/app/backup/cleanup_critical.go
@@ -41,13 +41,23 @@ func criticalCleanup(state *BackupExecutionState, logger applog.Logger) {
 		} else {
 			logger.Debugf("✓ Partial backup file terhapus: %s", currentFile)
 		}
-		state.ClearCurrentBackupFile()
-	}
 
-	// 2. Cleanup additional resources via state's Cleanup method
-	// Ini akan cleanup resources yang di-register via EnableCleanup()
-	// Contoh: lock files, temp directories, dll
-	state.Cleanup()
+		// Hapus metadata file jika ada (menghindari orphaned metadata)
+		metaFile := currentFile + ".meta.json"
+		if err := os.Remove(metaFile); err != nil {
+			logger.Debugf("Gagal menghapus metadata file (mungkin belum dibuat): %v", err)
+		} else {
+			logger.Debugf("✓ Metadata file terhapus: %s", metaFile)
+		}
+
+		// Panggil Cleanup dari state (berisi logika spesifik tambahan) SEBELUM state dibersihkan
+		state.Cleanup()
+
+		state.ClearCurrentBackupFile()
+	} else {
+		// Jika tidak ada current file, tetap panggil Cleanup untuk resources lain
+		state.Cleanup()
+	}
 
 	logger.Debug("Critical cleanup selesai")
 }

--- a/internal/app/backup/execution/builder.go
+++ b/internal/app/backup/execution/builder.go
@@ -17,7 +17,7 @@ import (
 )
 
 // maskDumpArgsForLog menghindari kebocoran kredensial saat menampilkan dump args ke log.
-// Saat ini yang di-mask: --password=... dan form dua-arg "--password" "..."
+// Saat ini yang di-mask: --password=... dan form dua-arg "--password" "..." serta short flag "-p"
 func maskDumpArgsForLog(args []string) []string {
 	if len(args) == 0 {
 		return args
@@ -30,8 +30,12 @@ func maskDumpArgsForLog(args []string) []string {
 			out = append(out, "--password=***")
 			continue
 		}
-		if al == "--password" {
-			out = append(out, "--password")
+		if strings.HasPrefix(al, "-p") && al != "-p" {
+			out = append(out, "-p***")
+			continue
+		}
+		if al == "--password" || al == "-p" {
+			out = append(out, a)
 			// mask next token value if present
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				out = append(out, "***")

--- a/internal/app/backup/execution/loop.go
+++ b/internal/app/backup/execution/loop.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"sfdbtools/internal/app/backup/model/types_backup"
@@ -76,7 +77,11 @@ func (e *Engine) ExecuteBackupLoop(
 			break
 		}
 
-		e.executeSingleBackupInLoop(ctx, dbName, idx+1, len(databases), config, outputPathFunc, &result)
+		if err := e.executeSingleBackupInLoop(ctx, dbName, idx+1, len(databases), config, outputPathFunc, &result); err != nil {
+			e.Log.Errorf("Menghentikan proses backup karena error kritikal: %v", err)
+			result.Errors = append(result.Errors, "Proses backup dihentikan karena error koneksi/autentikasi fatal")
+			break
+		}
 	}
 
 	return result
@@ -84,6 +89,7 @@ func (e *Engine) ExecuteBackupLoop(
 
 // executeSingleBackupInLoop executes backup untuk satu database dalam loop context.
 // Updates result object dengan success/failure info.
+// Mengembalikan error non-nil jika terjadi error fatal (connection/auth) untuk menghentikan loop.
 func (e *Engine) executeSingleBackupInLoop(
 	ctx context.Context,
 	dbName string,
@@ -91,14 +97,14 @@ func (e *Engine) executeSingleBackupInLoop(
 	config types_backup.BackupLoopConfig,
 	outputPathFunc func(string) (string, error),
 	result *types_backup.BackupLoopResult,
-) {
+) error {
 	// Early context check BEFORE starting backup
 	// Mencegah partial backup jika context sudah cancelled
 	select {
 	case <-ctx.Done():
 		e.Log.Warnf("⚠️  Backup cancelled before database %s (context done)", dbName)
 		result.Errors = append(result.Errors, fmt.Sprintf("Backup cancelled before %s", dbName))
-		return
+		return ctx.Err()
 	default:
 		// Context masih aktif, lanjut backup
 	}
@@ -116,7 +122,7 @@ func (e *Engine) executeSingleBackupInLoop(
 			Error:        msg,
 		})
 		result.Failed++
-		return
+		return nil
 	}
 
 	// Execute backup untuk database ini
@@ -135,7 +141,16 @@ func (e *Engine) executeSingleBackupInLoop(
 			Error:        err.Error(),
 		})
 		result.Failed++
-		return
+
+		// Circuit Breaker: jika error terkait koneksi atau autentikasi yang fatal, hentikan loop
+		errStr := strings.ToLower(err.Error())
+		if strings.Contains(errStr, "access denied") ||
+			strings.Contains(errStr, "connection refused") ||
+			strings.Contains(errStr, "can't connect") ||
+			strings.Contains(errStr, "unknown server") {
+			return fmt.Errorf("fatal connection/auth error: %w", err)
+		}
+		return nil
 	}
 
 	result.BackupInfos = append(result.BackupInfos, backupInfo)
@@ -155,4 +170,6 @@ func (e *Engine) executeSingleBackupInLoop(
 			}
 		}
 	}
+
+	return nil
 }

--- a/internal/app/backup/execution/retry.go
+++ b/internal/app/backup/execution/retry.go
@@ -246,9 +246,23 @@ func removeFlagArg(args []string, candidate string, rawToken string) ([]string, 
 		removed := arg
 
 		// Jika opsi dalam format dua-arg ("--opt" "value"), hapus value juga
+		// Hati-hati jangan sampai menelan argumen posisional (nama database) yang berada di akhir.
+		isNextArgPositional := false
+		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			allRemainingNonFlags := true
+			for j := i + 1; j < len(args); j++ {
+				if strings.HasPrefix(args[j], "-") {
+					allRemainingNonFlags = false
+					break
+				}
+			}
+			isNextArgPositional = allRemainingNonFlags
+		}
+
 		removeNextValue := !strings.Contains(arg, "=") &&
 			i+1 < len(args) &&
-			!strings.HasPrefix(args[i+1], "-")
+			!strings.HasPrefix(args[i+1], "-") &&
+			!isNextArgPositional
 
 		out := make([]string, 0, len(args))
 		out = append(out, args[:i]...)

--- a/internal/app/backup/grants/grants.go
+++ b/internal/app/backup/grants/grants.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"sfdbtools/internal/app/backup/metadata"
 	"sfdbtools/internal/app/usersgrants"
 	applog "sfdbtools/internal/services/log"
 	"sfdbtools/internal/shared/database"
+	"sfdbtools/internal/shared/fsops"
 )
 
 func defaultSystemUsers() []string {
@@ -54,21 +54,6 @@ func formatDatabasesForError(databases []string) string {
 	}
 	head := strings.Join(databases[:max], ",")
 	return fmt.Sprintf("%s,...(+%d)", head, len(databases)-max)
-}
-
-// parseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode.
-// Jika parsing gagal atau permissions kosong, return default 0600 (lebih restrictive).
-func parseFilePermissions(permStr string, logger applog.Logger) os.FileMode {
-	const defaultPerm = 0600
-	if strings.TrimSpace(permStr) == "" {
-		return defaultPerm
-	}
-	perm, err := strconv.ParseUint(strings.TrimSpace(permStr), 8, 32)
-	if err != nil {
-		logger.Warnf("Invalid metadata_permissions '%s', using default 0600: %v", permStr, err)
-		return defaultPerm
-	}
-	return os.FileMode(perm)
 }
 
 // ExportUserGrantsIfNeeded exports user grants unless excluded or in dry-run.
@@ -142,7 +127,7 @@ func ExportUserGrantsIfNeeded(
 
 		// Naming: karena isinya user definition, kita pakai _users.sql
 		userDefPath := metadata.GenerateUserDefinitionFilePath(referenceBackupFile)
-		perm := parseFilePermissions(metadataPermissions, log)
+		perm := fsops.ParseFilePermissions(metadataPermissions, 0600, log)
 		if err := os.WriteFile(userDefPath, []byte(sqlText), perm); err != nil {
 			log.Errorf("Gagal menulis file user definitions: %v", err)
 			return "", "", nil
@@ -180,7 +165,7 @@ func ExportUserGrantsIfNeeded(
 		return "", "", handleExportError(err, databases, requireGrants, log)
 	}
 
-	perm := parseFilePermissions(metadataPermissions, log)
+	perm := fsops.ParseFilePermissions(metadataPermissions, 0600, log)
 
 	// Write Users
 	userDefPath := metadata.GenerateUserDefinitionFilePath(referenceBackupFile)
@@ -222,8 +207,7 @@ func handleExportError(err error, databases []string, requireGrants bool, log ap
 
 // UpdateMetadataUserGrantsPath updates backup metadata with the actual user grants file path.
 func UpdateMetadataUserGrantsPath(log applog.Logger, backupFilePath string, userDefPath string, userGrantsPath string, permissions string) {
-	// Kita reuse key UserGrantsFile di metadata untuk path grants.
-	// Jika userDefPath ada, kita mungkin perlu method update baru atau update manual.
-	// TODO: Pastikan method di metadata.Updater support path tambahan atau kita update satu-satu.
-	// Saat ini hanya stub karena engine.go yang memanggil method ini perlu diupdate juga.
+	if err := metadata.UpdateMetadataUserFiles(backupFilePath, userDefPath, userGrantsPath, permissions, log); err != nil {
+		log.Warnf("Gagal mengupdate path file user/grants ke metadata: %v", err)
+	}
 }

--- a/internal/app/backup/metadata/updater.go
+++ b/internal/app/backup/metadata/updater.go
@@ -14,8 +14,8 @@ import (
 	"sfdbtools/internal/shared/consts"
 )
 
-// UpdateMetadataUserGrantsFile membaca metadata yang ada, update UserGrantsFile field, dan save kembali
-func UpdateMetadataUserGrantsFile(backupFilePath string, userGrantsPath string, permissions string, logger applog.Logger) error {
+// UpdateMetadataUserFiles membaca metadata yang ada, update UserGrantsFile dan UserDefinitionFile field, dan save kembali
+func UpdateMetadataUserFiles(backupFilePath string, userDefPath string, userGrantsPath string, permissions string, logger applog.Logger) error {
 	manifestPath := backupFilePath + consts.ExtMetaJSON
 
 	// Baca metadata yang ada
@@ -35,6 +35,13 @@ func UpdateMetadataUserGrantsFile(backupFilePath string, userGrantsPath string, 
 		meta.UserGrantsFile = "none"
 	} else {
 		meta.UserGrantsFile = userGrantsPath
+	}
+
+	// Update UserDefinitionFile - jika empty string, set ke "none"
+	if userDefPath == "" {
+		meta.UserDefinitionFile = "none"
+	} else {
+		meta.UserDefinitionFile = userDefPath
 	}
 
 	// Save kembali

--- a/internal/app/backup/metadata/writer.go
+++ b/internal/app/backup/metadata/writer.go
@@ -13,7 +13,7 @@ import (
 	"sfdbtools/internal/app/backup/model/types_backup"
 	applog "sfdbtools/internal/services/log"
 	"sfdbtools/internal/shared/consts"
-	"strconv"
+	"sfdbtools/internal/shared/fsops"
 )
 
 // SaveBackupMetadata menyimpan metadata ke file dengan atomic write
@@ -28,7 +28,7 @@ func SaveBackupMetadata(meta *types_backup.BackupMetadata, permissions string, l
 	tmpManifest := manifestPath + consts.ExtTmp
 
 	// Parse permissions string to os.FileMode
-	perm := parseFilePermissions(permissions, logger)
+	perm := fsops.ParseFilePermissions(permissions, 0600, logger)
 
 	// Marshal metadata to JSON
 	manifestBytes, err := json.MarshalIndent(meta, "", "  ")
@@ -71,23 +71,4 @@ func TrySaveBackupMetadata(meta *types_backup.BackupMetadata, permissions string
 	}
 
 	return path
-}
-
-// parseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode
-// Jika parsing gagal atau permissions kosong, return default 0600 (lebih restrictive)
-func parseFilePermissions(permStr string, logger applog.Logger) os.FileMode {
-	const defaultPerm = 0600
-
-	if permStr == "" {
-		return defaultPerm
-	}
-
-	// Parse octal string to uint32
-	perm, err := strconv.ParseUint(permStr, 8, 32)
-	if err != nil {
-		logger.Warnf("Invalid metadata_permissions '%s', using default 0600: %v", permStr, err)
-		return defaultPerm
-	}
-
-	return os.FileMode(perm)
 }

--- a/internal/app/backup/modes/iterative.go
+++ b/internal/app/backup/modes/iterative.go
@@ -91,7 +91,7 @@ func (e *IterativeExecutor) Execute(ctx context.Context, dbList []string) types_
 
 		if isSinglePrimaryPackage(dbList) {
 			e.generateCombinedMetadata(loopResult, dbList)
-			res.BackupInfo = e.aggregateBackupInfos(loopResult.BackupInfos)
+			res.BackupInfo = e.aggregateBackupInfos(loopResult.BackupInfos, dbList)
 		}
 	}
 
@@ -165,16 +165,24 @@ func (e *IterativeExecutor) createOutputPathFunc(dbList []string) func(string) (
 
 // aggregateBackupInfos menggabungkan multiple backup infos menjadi satu entry
 // Digunakan untuk primary/secondary yang backup multiple databases tapi display sebagai satu
-func (e *IterativeExecutor) aggregateBackupInfos(backupInfos []types_backup.DatabaseBackupInfo) []types_backup.DatabaseBackupInfo {
+func (e *IterativeExecutor) aggregateBackupInfos(backupInfos []types_backup.DatabaseBackupInfo, dbList []string) []types_backup.DatabaseBackupInfo {
 	if len(backupInfos) == 0 {
 		return backupInfos
 	}
 
-	// Ambil info pertama sebagai base
-	aggregated := backupInfos[0]
+	primaryIndex := 0
+	for i, info := range backupInfos {
+		if len(dbList) > 0 && info.DatabaseName == dbList[0] {
+			primaryIndex = i
+			break
+		}
+	}
+
+	// Ambil info utama sebagai base
+	aggregated := backupInfos[primaryIndex]
 
 	// Update database name untuk menunjukkan multiple databases
-	aggregated.DatabaseName = fmt.Sprintf("%s + %d companion databases", backupInfos[0].DatabaseName, len(backupInfos)-1)
+	aggregated.DatabaseName = fmt.Sprintf("%s + %d companion databases", aggregated.DatabaseName, len(backupInfos)-1)
 
 	// Sum up file sizes dari semua backup
 	totalSize := int64(0)
@@ -184,8 +192,8 @@ func (e *IterativeExecutor) aggregateBackupInfos(backupInfos []types_backup.Data
 	aggregated.FileSize = totalSize
 	aggregated.FileSizeHuman = fmt.Sprintf("%.2f MB", float64(totalSize)/(1024*1024))
 
-	// Metadata file adalah dari database pertama (combined metadata)
-	aggregated.ManifestFile = backupInfos[0].OutputFile + consts.ExtMetaJSON
+	// Metadata file adalah dari database yang terpilih sebagai base
+	aggregated.ManifestFile = aggregated.OutputFile + consts.ExtMetaJSON
 
 	return []types_backup.DatabaseBackupInfo{aggregated}
 }
@@ -200,23 +208,32 @@ func (e *IterativeExecutor) generateCombinedMetadata(loopResult types_backup.Bac
 
 	e.service.GetLog().Debug(fmt.Sprintf("Generating combined metadata untuk %d databases", len(dbList)))
 
+	// Cari primary file, prioritas pada index asli primary db
+	primaryIndex := 0
+	for i, info := range loopResult.BackupInfos {
+		if len(dbList) > 0 && info.DatabaseName == dbList[0] {
+			primaryIndex = i
+			break
+		}
+	}
+
 	// Untuk primary/secondary:
 	// 1. Update metadata pertama dengan DatabaseNames dan DatabaseDetails (info lengkap per database)
 	// 2. Hapus semua metadata individual untuk companion databases
 
-	// Update metadata pertama dengan full database list dan details
-	primaryBackupFile := loopResult.BackupInfos[0].OutputFile
+	// Update metadata utama dengan full database list dan details
+	primaryBackupFile := loopResult.BackupInfos[primaryIndex].OutputFile
 	permissions := e.service.GetConfig().Backup.Output.MetadataPermissions
 	if err := metadata.UpdateMetadataWithDatabaseDetails(primaryBackupFile, dbList, loopResult.BackupInfos, permissions, e.service.GetLog()); err != nil {
 		e.service.GetLog().Warn("Gagal update combined metadata: " + err.Error())
 	}
 
-	// Hapus metadata individual untuk companion databases (index 1+)
+	// Hapus metadata individual untuk database lainnya
 	for i, info := range loopResult.BackupInfos {
-		if i == 0 {
+		if i == primaryIndex {
 			continue
 		}
-		// Companion databases: hapus metadata individual
+		// Hapus metadata individual
 		metadataPath := info.OutputFile + consts.ExtMetaJSON
 		e.service.GetLog().Debug("Menghapus metadata companion: " + metadataPath)
 		os.Remove(metadataPath)

--- a/internal/app/backup/service.go
+++ b/internal/app/backup/service.go
@@ -35,6 +35,13 @@ type BackupExecutionState struct {
 	mu                sync.Mutex
 }
 
+// SetExcludedDatabases updates the excluded databases list safely
+func (s *BackupExecutionState) SetExcludedDatabases(excluded []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ExcludedDatabases = excluded
+}
+
 // SetCurrentBackupFile mencatat file backup yang sedang dibuat (thread-safe)
 func (s *BackupExecutionState) SetCurrentBackupFile(filePath string) {
 	s.mu.Lock()

--- a/internal/app/backup/setup/config.go
+++ b/internal/app/backup/setup/config.go
@@ -15,15 +15,19 @@ import (
 	"sfdbtools/internal/ui/prompt"
 )
 
-type Setup struct {
-	Log               applog.Logger
-	Config            *appconfig.Config
-	Options           *types_backup.BackupDBOptions
-	ExcludedDatabases *[]string
+type StateUpdater interface {
+	SetExcludedDatabases([]string)
 }
 
-func New(log applog.Logger, cfg *appconfig.Config, opts *types_backup.BackupDBOptions, excluded *[]string) *Setup {
-	return &Setup{Log: log, Config: cfg, Options: opts, ExcludedDatabases: excluded}
+type Setup struct {
+	Log          applog.Logger
+	Config       *appconfig.Config
+	Options      *types_backup.BackupDBOptions
+	StateUpdater StateUpdater
+}
+
+func New(log applog.Logger, cfg *appconfig.Config, opts *types_backup.BackupDBOptions, updater StateUpdater) *Setup {
+	return &Setup{Log: log, Config: cfg, Options: opts, StateUpdater: updater}
 }
 
 // isInteractiveMode adalah source-of-truth tunggal untuk mode-mode backup yang

--- a/internal/app/backup/setup/session.go
+++ b/internal/app/backup/setup/session.go
@@ -96,11 +96,11 @@ func (s *Setup) PrepareBackupSession(ctx context.Context, headerTitle string, no
 			return nil, nil, fmt.Errorf("gagal mendapatkan daftar database: %w", err)
 		}
 
-		if s.Options.Mode == consts.ModeAll && stats != nil && s.ExcludedDatabases != nil {
-			*s.ExcludedDatabases = stats.ExcludedDatabases
-			s.Log.Infof("Menyimpan %d excluded databases untuk metadata", len(*s.ExcludedDatabases))
-			if len(*s.ExcludedDatabases) > 0 {
-				s.Log.Debugf("Excluded databases: %v", *s.ExcludedDatabases)
+		if s.Options.Mode == consts.ModeAll && stats != nil && s.StateUpdater != nil {
+			s.StateUpdater.SetExcludedDatabases(stats.ExcludedDatabases)
+			s.Log.Infof("Menyimpan %d excluded databases untuk metadata", len(stats.ExcludedDatabases))
+			if len(stats.ExcludedDatabases) > 0 {
+				s.Log.Debugf("Excluded databases: %v", stats.ExcludedDatabases)
 			}
 		}
 

--- a/internal/app/backup/writer/engine.go
+++ b/internal/app/backup/writer/engine.go
@@ -197,19 +197,38 @@ func (e *Engine) isFatalDumpError(toolName string, err error, stderrOutput strin
 	return true
 }
 
-// isRetryableError menentukan apakah error bisa di-retry (seperti SSL mismatch)
-// Error yang bisa di-retry tidak perlu log path di writer layer karena akan di-handle di execution layer
-// Fungsi ini menggunakan pattern yang sama dengan execution.IsSSLMismatchRequiredButServerNoSupport
-// untuk konsistensi deteksi retry-able errors
-func (e *Engine) isRetryableError(stderrOutput string) bool {
-	if stderrOutput == "" {
-		return false
+// CappedBuffer limits the amount of data stored to prevent OOM
+type CappedBuffer struct {
+	maxBytes int
+	buffer   []byte
+	overflow bool
+}
+
+func newCappedBuffer(maxBytes int) *CappedBuffer {
+	return &CappedBuffer{
+		maxBytes: maxBytes,
+		buffer:   make([]byte, 0, 1024),
 	}
-	stderrLower := strings.ToLower(stderrOutput)
-	// SSL mismatch adalah retry-able error (pattern sama dengan execution.IsSSLMismatchRequiredButServerNoSupport)
-	return strings.Contains(stderrLower, "tls/ssl error") &&
-		strings.Contains(stderrLower, "ssl is required") &&
-		strings.Contains(stderrLower, "server does not support")
+}
+
+func (c *CappedBuffer) Write(p []byte) (n int, err error) {
+	if len(c.buffer)+len(p) > c.maxBytes {
+		allowed := c.maxBytes - len(c.buffer)
+		if allowed > 0 {
+			c.buffer = append(c.buffer, p[:allowed]...)
+		}
+		c.overflow = true
+	} else {
+		c.buffer = append(c.buffer, p...)
+	}
+	return len(p), nil // Always report successful write of all bytes to not break cmd.Run
+}
+
+func (c *CappedBuffer) String() string {
+	if c.overflow {
+		return string(c.buffer) + "\n... (output truncated due to size limit)"
+	}
+	return string(c.buffer)
 }
 
 // parseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode
@@ -319,8 +338,9 @@ func (e *Engine) ExecuteMysqldumpWithPipe(ctx context.Context, mysqldumpArgs []s
 	monitor := newDatabaseMonitorWriter(writer, spin, e.Log)
 	cmd.Stdout = monitor
 
-	var stderrBuf strings.Builder
-	cmd.Stderr = &stderrBuf
+	// Use CappedBuffer (max 1MB) for stderr to prevent OOM
+	stderrBuf := newCappedBuffer(1 * 1024 * 1024)
+	cmd.Stderr = stderrBuf
 
 	runErr := cmd.Run()
 

--- a/internal/shared/fsops/permissions.go
+++ b/internal/shared/fsops/permissions.go
@@ -1,0 +1,26 @@
+package fsops
+
+import (
+	"os"
+	"strconv"
+
+	applog "sfdbtools/internal/services/log"
+)
+
+// ParseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode.
+// Jika parsing gagal atau permissions kosong, return defaultPerm.
+func ParseFilePermissions(permStr string, defaultPerm os.FileMode, logger applog.Logger) os.FileMode {
+	if permStr == "" {
+		return defaultPerm
+	}
+
+	perm, err := strconv.ParseUint(permStr, 8, 32)
+	if err != nil {
+		if logger != nil {
+			logger.Warnf("Invalid file_permissions '%s', using default: %v", permStr, err)
+		}
+		return defaultPerm
+	}
+
+	return os.FileMode(perm)
+}


### PR DESCRIPTION
This PR implements several critical fixes and optimizations to make the backup module fully production-ready and resilient.

## Changes:
- **Resilience:** Implemented a Circuit Breaker in `loop.go` to safely abort on fatal network/auth errors rather than running through all remaining databases.
- **Resource Management:** Added `CappedBuffer` in `writer/engine.go` for `cmd.Stderr` to cap logs to 1MB, preventing OOM when millions of warnings are produced.
- **Bug Fixes:** 
  - Fixed `removeFlagArg` parsing bug in `retry.go` to prevent swallowing database names during option stripping.
  - Re-ordered state cleanup logic in `cleanup_critical.go` and `service.go` to properly delete orphaned `.meta.json` files during `SIGINT`/`SIGTERM` interrupts.
  - Implemented the `UpdateMetadataUserGrantsPath` stub in `grants.go` to accurately reflect user grants output paths in `.meta.json`.
  - Corrected combined metadata generation index assumption in `modes/iterative.go`.
- **Security:** Hardened `maskDumpArgsForLog` to safely mask the short `-p` password flag.
- **Refactoring:** Eliminated pointer-to-slice anti-patterns in the `Setup` struct by introducing the `StateUpdater` interface and extracted permission mapping into `internal/shared/fsops/permissions.go`.