### PR TITLE
feat(backup): implement systemd timer based scheduler driven by config.yaml

### DIFF
--- a/.omg/state/learn-watch.json
+++ b/.omg/state/learn-watch.json
@@ -1,6 +1,6 @@
 {
-  "last_session_id": "a1e53197-8618-4d65-ad59-07833a7fc4b9",
-  "last_event_key": "a1e53197-8618-4d65-ad59-07833a7fc4b9:transcript:90753778f66d6b3937eeba738b181d01b745f022d9e76a6089271d031aa9215a",
+  "last_session_id": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf",
+  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
   "last_prompted_session_id": "a1e53197-8618-4d65-ad59-07833a7fc4b9",
   "last_reason": "short-session",
   "last_prompted_at": "2026-04-23T03:46:51.329Z",
@@ -8,5 +8,5 @@
   "last_actionable_message_count": 0,
   "deep_interview_lock_active": false,
   "deep_interview_lock_source": "/home/dbado/sfDBTools/.omg/state/deep-interview.json",
-  "updated_at": "2026-04-23T09:57:28.519Z"
+  "updated_at": "2026-04-24T06:37:01.211Z"
 }

--- a/.omg/state/learn-watch.json
+++ b/.omg/state/learn-watch.json
@@ -1,6 +1,6 @@
 {
   "last_session_id": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf",
-  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
+  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:3acca718d33a339615728e1492210a603d766c88dc0f36f9a1b195b9501b3975",
   "last_prompted_session_id": "a1e53197-8618-4d65-ad59-07833a7fc4b9",
   "last_reason": "short-session",
   "last_prompted_at": "2026-04-23T03:46:51.329Z",
@@ -8,5 +8,5 @@
   "last_actionable_message_count": 0,
   "deep_interview_lock_active": false,
   "deep_interview_lock_source": "/home/dbado/sfDBTools/.omg/state/deep-interview.json",
-  "updated_at": "2026-04-24T06:37:01.211Z"
+  "updated_at": "2026-04-24T07:15:41.779Z"
 }

--- a/.omg/state/quota-watch.json
+++ b/.omg/state/quota-watch.json
@@ -1,9 +1,9 @@
 {
   "turn_count": 0,
   "last_session_id": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf",
-  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
-  "last_transcript_hash": "c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
+  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:3acca718d33a339615728e1492210a603d766c88dc0f36f9a1b195b9501b3975",
+  "last_transcript_hash": "3acca718d33a339615728e1492210a603d766c88dc0f36f9a1b195b9501b3975",
   "cwd_mode": "parent-leaf",
   "last_cwd_label": "dbado/sfDBTools",
-  "updated_at": "2026-04-24T06:37:01.286Z"
+  "updated_at": "2026-04-24T07:15:41.815Z"
 }

--- a/.omg/state/quota-watch.json
+++ b/.omg/state/quota-watch.json
@@ -1,9 +1,9 @@
 {
-  "turn_count": 28,
-  "last_session_id": "a1e53197-8618-4d65-ad59-07833a7fc4b9",
-  "last_event_key": "a1e53197-8618-4d65-ad59-07833a7fc4b9:transcript:90753778f66d6b3937eeba738b181d01b745f022d9e76a6089271d031aa9215a",
-  "last_transcript_hash": "90753778f66d6b3937eeba738b181d01b745f022d9e76a6089271d031aa9215a",
+  "turn_count": 0,
+  "last_session_id": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf",
+  "last_event_key": "1ae2b71d-08a5-4f41-bd8a-b8f17ca02ebf:transcript:c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
+  "last_transcript_hash": "c9154c4dbdf0207076df487376849fbb046cb10da26ea7fa4a69f69c54b52a8b",
   "cwd_mode": "parent-leaf",
   "last_cwd_label": "dbado/sfDBTools",
-  "updated_at": "2026-04-23T09:57:28.559Z"
+  "updated_at": "2026-04-24T06:37:01.286Z"
 }

--- a/cmd/backup/filter.go
+++ b/cmd/backup/filter.go
@@ -62,8 +62,16 @@ func getBackupMode(cmd *cobra.Command) (string, error) {
 	// Dapatkan mode dari flag
 	mode, _ := cmd.Flags().GetString("mode")
 
-	// Jika mode tidak di-provide (masih default "single-file"), tanyakan interaktif
+	// Jika mode tidak di-set secara eksplisit, tanyakan interaktif atau gunakan default
 	if !cmd.Flags().Changed("mode") {
+		// Cek apakah dalam mode non-interaktif (--quiet)
+		isQuiet, _ := cmd.Root().PersistentFlags().GetBool("quiet")
+		if isQuiet {
+			// Dalam mode scheduler/non-interaktif: default ke multi-file (satu file per DB)
+			// Ini adalah perilaku paling aman untuk automated backup
+			return consts.ModeSeparated, nil
+		}
+
 		modeOptions := []string{
 			"single-file (gabungkan semua database dalam satu file)",
 			"multi-file (pisahkan setiap database ke file terpisah)",

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -32,4 +32,5 @@ func init() {
 	CmdBackupMain.AddCommand(CmdBackupSingle)
 	CmdBackupMain.AddCommand(CmdBackupPrimary)
 	CmdBackupMain.AddCommand(CmdBackupSecondary)
+	CmdBackupMain.AddCommand(CmdBackupSchedule)
 }

--- a/cmd/backup/schedule.go
+++ b/cmd/backup/schedule.go
@@ -1,0 +1,60 @@
+package backupcmd
+
+import (
+	"fmt"
+	"sfdbtools/internal/app/backup/scheduler"
+	appdeps "sfdbtools/internal/cli/deps"
+
+	"github.com/spf13/cobra"
+)
+
+var CmdBackupSchedule = &cobra.Command{
+	Use:   "schedule",
+	Short: "Kelola penjadwalan backup (systemd timers)",
+	Long:  "Mengelola penjadwalan backup secara otomatis menggunakan systemd timers, dikonfigurasi melalui config.yaml",
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var CmdBackupScheduleSync = &cobra.Command{
+	Use:   "sync",
+	Short: "Sinkronisasi config.yaml menjadi systemd timers",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		deps := appdeps.Deps
+		if deps == nil || deps.Config == nil {
+			return fmt.Errorf("konfigurasi aplikasi belum dimuat")
+		}
+
+		mgr := scheduler.NewManager(deps.Config, deps.Logger)
+		if err := mgr.Sync(cmd.Context()); err != nil {
+			return fmt.Errorf("gagal sync scheduler: %w", err)
+		}
+		
+		deps.Logger.Info("Sinkronisasi jadwal backup berhasil.")
+		return nil
+	},
+}
+
+var CmdBackupScheduleStatus = &cobra.Command{
+	Use:   "status",
+	Short: "Lihat status seluruh job scheduler backup",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		deps := appdeps.Deps
+		if deps == nil || deps.Config == nil {
+			return fmt.Errorf("konfigurasi aplikasi belum dimuat")
+		}
+
+		mgr := scheduler.NewManager(deps.Config, deps.Logger)
+		if err := mgr.ShowStatus(cmd.Context()); err != nil {
+			return fmt.Errorf("gagal menampilkan status scheduler: %w", err)
+		}
+		
+		return nil
+	},
+}
+
+func init() {
+	CmdBackupSchedule.AddCommand(CmdBackupScheduleSync)
+	CmdBackupSchedule.AddCommand(CmdBackupScheduleStatus)
+}

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,0 +1,128 @@
+# Default configuration for sfDBTools (safe defaults, no secrets)
+# Copy to /etc/sfDBTools/config.yaml if you want system-wide config.
+
+backup:
+  compression:
+    type: zstd # Tipe kompresi: gzip, zstd, xz, zlib, pgzip, none
+    level: 5 # Compression level dari 1 (tercepat, kompresi paling rendah) hingga 9 (paling lambat, kompresi paling tinggi)
+    enabled: true
+  mysqldump_args: -fQq --max-statement-time=0 --max-allowed-packet=1G --hex-blob --order-by-primary --single-transaction --routines=true --triggers=true --opt --net-buffer-length=16M
+  exclude:
+    user: false
+    system_databases: true
+    data: false
+    empty: false
+  include:
+    include_dmart: true
+    # databases:
+    #   - dbsf_biznet_dadfs
+    #   - dbsf_biznet_jtrust
+    #   - dbsf_biznet_mariadb
+    # file : config/db_list.txt
+  cleanup:
+    # Cleanup retention untuk file backup lama.
+    # Jika ingin dijalankan otomatis via systemd timer:
+    # - set enabled=true dan schedule (cron 5 kolom)
+    # - jalankan: sfDBTools cleanup schedule start
+    enabled: false
+    schedule: "" # contoh: "0 2 * * *" (tiap hari 02:00)
+    days: 0 # jumlah hari retensi (0 = tidak melakukan delete)
+  encryption:
+    enabled: true
+  output:
+    # base_directory: /media/ArchiveDB
+    # Filename pattern menggunakan format fixed:
+    # {database}_{year}{month}{day}_{hour}{minute}{second}_{hostname}
+    # Contoh: mydb_20251110_143025_dbserver1.sql.gz.enc
+    base_directory: /media/ArchiveDB
+    filename_pattern: "{database}_{year}{month}{day}_{hour}{minute}{second}_{hostname}"
+    file_permissions: "0600" # File permissions untuk backup files (default: 0600 untuk keamanan)
+    metadata_permissions: "0600" # File permissions untuk metadata (default: 0600 untuk keamanan)
+    structure:
+      create_subdirs: true
+      pattern: "{year}{month}{day}/"
+    save_backup_info: true
+  verification:
+    disk_space_check: false
+  replication:
+    capture_gtid: true
+    replication_user: repl_user
+    replication_password: repl_password
+
+  # Scheduler backup berbasis systemd timer.
+  # - Format schedule menggunakan cron (5 kolom)
+  # - Banyak job diperbolehkan (local/NFS/NAS, harian/mingguan/bulanan, dll)
+  # - Eksekusi job dipaksa SERIAL (antri) via global lock (tidak paralel)
+  scheduler:
+    jobs:
+      # - name: local_daily
+      #   enabled: true
+      #   schedule: "0 2 * * *" # tiap hari 02:00
+      #   mode: separated
+      #   include_file: /etc/sfDBTools/config/db_list.txt
+      #   profile: /etc/sfDBTools/config/db_profile/source.cnf.enc
+      #   ticket: "SCHEDULED"
+      #   output:
+      #     base_directory: /backup/local
+      #   cleanup:
+      #     enabled: true
+      #     retention_days: 7
+      #
+      # - name: nfs_every_3_days
+      #   enabled: true
+      #   schedule: "0 1 */3 * *" # tiap 3 hari 01:00
+      #   mode: separated
+      #   include_file: /etc/sfDBTools/config/db_list.txt
+      #   profile: /etc/sfDBTools/config/db_profile/source.cnf.enc
+      #   ticket: "SCHEDULED"
+      #   output:
+      #     base_directory: /mnt/nfs/backup
+      #   cleanup:
+      #     enabled: true
+      #     retention_days: 14
+
+config_dir:
+  database_profile: /etc/sfDBTools/config/db_profile
+
+general:
+  locale:
+    date_format: "2006-01-02"
+    time_format: "15:04:05"
+    timezone: Asia/Jakarta
+
+log:
+  format: text
+  level: DEBUG #TRACE, DEBUG, INFO, WARN, ERROR, FATAL, PANIC
+  output:
+    console:
+      enabled: true
+    file:
+      dir: /var/log/sfDBTools
+      enabled: true
+      filename_pattern: sfDBTools_{date}.log
+      rotation:
+        compress_old: true
+        daily: true
+        max_size: 100MB
+        retention_days: 7
+  timezone: Asia/Jakarta
+
+profile:
+  connection:
+    timeout: 30s
+
+mariadb:
+  # Opsional: override path key material MariaDB untuk derive master key ENV terenkripsi.
+  # Jika dikosongkan, sfDBTools akan fallback ke default: /var/lib/mysql/key_maria_nbc.txt
+  key_maria_nbc_file: ""
+
+script:
+  # Jika diisi, output file .sftools dari `sfDBTools script encrypt` akan disimpan ke folder ini.
+  # Jika kosong, default: satu folder dengan file entrypoint.
+  bundle_output_dir: "/etc/sfDBTools/scripts"
+
+db_user:
+  export:
+    include_create_user: true
+    include_grants: true
+    split_output: true

--- a/docs/improvement/backup-feature-roadmap.md
+++ b/docs/improvement/backup-feature-roadmap.md
@@ -1,0 +1,426 @@
+# sfDBTools Backup — Production-Grade Feature Roadmap (MariaDB)
+
+> **Author**: AI-assisted  
+> **Created**: 2026-04-24  
+> **Status**: Draft / Open for Review
+
+## Background
+
+Berdasarkan analisis codebase yang sudah ada, `sfDBTools backup` saat ini sudah memiliki foundation yang solid:
+
+### Fitur Yang Sudah Ada
+| Capability | Status |
+|---|---|
+| Multi-mode backup (single, separated, combined, all, primary, secondary) | ✅ |
+| Compression (gzip, zstd, xz, zlib, pgzip) | ✅ |
+| Encryption (AES) | ✅ |
+| GTID Capture (MariaDB `BINLOG_GTID_POS`) | ✅ |
+| User & Grant Export (split CREATE USER + GRANT) | ✅ |
+| Rich Metadata (`.meta.json` per backup) | ✅ |
+| Retry Strategy (SSL mismatch, unsupported option) | ✅ |
+| Graceful Shutdown + Partial File Cleanup | ✅ |
+| Non-interactive / Background mode | ✅ |
+| Systemd Timer Scheduler (in progress) | 🔨 |
+| Cleanup by Retention Days | ✅ (basic) |
+| Restore (interactive & companion-aware) | ✅ |
+
+### Gap Untuk Production-Grade DBA Tooling
+
+Yang **belum ada** dan sangat dibutuhkan seorang DBA di production:
+
+---
+
+## Proposed Features
+
+### Feature 1: Backup Verification & Integrity Check
+**Priority: 🔴 Critical** · **Complexity: Medium**
+
+> *"Backup tanpa verification = tidak punya backup."*
+
+Saat ini backup hanya dicek dari exit code `mariadb-dump`. Tidak ada validasi apakah file backup benar-benar restorable.
+
+#### Key Capabilities
+1. **Post-Backup Integrity Check** — Otomatis setelah backup selesai:
+   - Checksum generation (SHA-256) disimpan di metadata
+   - Header validation (cek SQL `-- MariaDB dump` header ada & valid)
+   - Footer validation (cek `-- Dump completed` footer ada)
+   - File size sanity check (> 0 bytes, dan > minimum threshold)
+   
+2. **Standalone Verify Command** — DBA bisa verify kapan saja:
+   - `sfdbtools backup verify <file>` — Verify single file
+   - `sfdbtools backup verify --dir <path>` — Verify semua backup di directory
+   - `sfdbtools backup verify --latest` — Verify backup terbaru
+
+3. **Restore Test (Dry-Run Restore)** — Level verifikasi tertinggi:
+   - Parse SQL backup ke temporary database, tanpa persist
+   - Cek semua `CREATE TABLE`, `INSERT` statement valid
+   - Report: table count, row count estimate, schema consistency
+
+#### Config Schema
+```yaml
+backup:
+  verification:
+    enabled: true
+    checksum_algorithm: sha256  # sha256, md5
+    post_backup_check: true     # auto-verify setelah backup
+    header_footer_check: true   # validasi SQL dump structure
+    min_file_size: 1KB          # minimum acceptable file size
+```
+
+#### CLI Commands
+```bash
+sfdbtools backup verify <backup-file>
+sfdbtools backup verify --dir /media/ArchiveDB/20260424/
+sfdbtools backup verify --latest --profile source.cnf.enc
+sfdbtools backup verify --checksum-only <backup-file>
+```
+
+#### Proposed File Structure
+```
+internal/app/backup/
+├── verify/
+│   ├── checker.go          # Core verification engine
+│   ├── checksum.go         # SHA-256/MD5 generation & comparison
+│   ├── header_validator.go # SQL dump header/footer check
+│   ├── size_validator.go   # File size sanity check
+│   ├── restore_test.go     # Dry-run restore verification
+│   └── report.go           # Verification result reporting
+cmd/backup/
+├── verify.go               # CLI command
+```
+
+---
+
+### Feature 2: Backup Catalog & History
+**Priority: 🔴 Critical** · **Complexity: Medium**
+
+> *"Saya punya 500 file backup, mana yang terbaru untuk `dbsf_biznet_jtrust`?"*
+
+DBA butuh satu tempat untuk melihat semua backup yang ada, history, dan status.
+
+#### Key Capabilities
+1. **Catalog Index** — Local JSON/SQLite index yang track semua backups:
+   - Database name, backup time, file size, mode, status
+   - Checksum, compression type, encrypted status
+   - GTID position (untuk PITR chain tracking)
+
+2. **List/Search Commands**:
+   - `sfdbtools backup list` — Tampilkan semua backup terbaru
+   - `sfdbtools backup list --db <name>` — Filter by database
+   - `sfdbtools backup list --since 7d` — Filter by time range
+   - `sfdbtools backup list --status failed` — Filter by status
+
+3. **Backup Report** — Summary untuk reporting:
+   - Total backup size per hari/minggu/bulan
+   - Success/failure rate
+   - Database coverage (DB mana yang belum di-backup?)
+   - Storage trend (growth rate)
+
+4. **Auto-catalog** — Setiap backup otomatis register ke catalog
+
+#### CLI Commands
+```bash
+# Listing
+sfdbtools backup list
+sfdbtools backup list --db dbsf_biznet_jtrust
+sfdbtools backup list --since 7d --format table
+sfdbtools backup list --since 30d --format json
+
+# Report
+sfdbtools backup report --period weekly
+sfdbtools backup report --period monthly --format markdown
+
+# Catalog management
+sfdbtools backup catalog rebuild --dir /media/ArchiveDB
+sfdbtools backup catalog prune   # hapus entry yang file-nya sudah tidak ada
+```
+
+#### Proposed File Structure
+```
+internal/app/backup/
+├── catalog/
+│   ├── store.go        # Catalog storage (JSON-based, upgrade path ke SQLite)
+│   ├── indexer.go       # Auto-index setelah backup
+│   ├── query.go         # Search & filter
+│   ├── report.go        # Summary & reporting
+│   └── model.go         # Catalog entry types
+cmd/backup/
+├── list.go              # CLI: backup list
+├── report.go            # CLI: backup report
+├── catalog.go           # CLI: catalog management
+```
+
+---
+
+### Feature 3: Incremental / Differential Backup Support
+**Priority: 🟡 High** · **Complexity: High**
+
+> *"Full backup 200GB tiap hari terlalu lama dan boros storage."*
+
+Untuk database besar, full backup setiap hari tidak feasible. DBA butuh strategi incremental.
+
+#### Key Capabilities
+1. **Mariabackup Integration** — Physical backup tool (bukan logical dump):
+   - Full backup sebagai base
+   - Incremental backup berdasarkan LSN (Log Sequence Number)
+   - Differential backup (delta dari full terakhir)
+
+2. **Backup Chain Management**:
+   - Track full → incremental chain
+   - Validate chain completeness sebelum restore
+   - Auto-detect kapan perlu full backup baru (chain terlalu panjang)
+
+3. **Strategy Configuration**:
+   ```yaml
+   backup:
+     strategy:
+       type: incremental     # full, incremental, differential
+       full_backup_day: sunday  # kapan full backup
+       max_chain_length: 6   # max incremental sebelum force full
+       tool: mariabackup     # mariabackup atau mariadb-dump
+   ```
+
+4. **Hybrid Mode** — Logical dump (mariadb-dump) + Physical backup (mariabackup):
+   - Logical: untuk portability & single-table restore
+   - Physical: untuk speed & PITR
+
+#### CLI Commands
+```bash
+# Incremental backup
+sfdbtools backup incremental --profile source.cnf.enc --ticket INC-001
+
+# Prepare (apply incremental ke full)
+sfdbtools backup prepare --base <full-backup-dir> --incremental <inc-dir>
+
+# Chain status
+sfdbtools backup chain status --profile source.cnf.enc
+```
+
+> **⚠️ Note:** Feature ini membutuhkan `mariabackup` binary terinstall di server.
+> Logical dump (mariadb-dump) **tidak mendukung** incremental secara native.
+> Perlu evaluasi apakah ini align dengan workflow tim.
+
+---
+
+### Feature 4: Backup Health Monitoring & Alerting
+**Priority: 🟡 High** · **Complexity: Medium**
+
+> *"Backup gagal 3 hari berturut-turut dan tidak ada yang tahu."*
+
+#### Key Capabilities
+1. **Health Check Command**:
+   - Cek backup terbaru per database (freshness check)
+   - Alert jika backup lebih dari N jam/hari
+   - Cek disk space availability sebelum backup
+   - Cek backup chain integrity
+
+2. **Notification Hooks** (Webhook-based):
+   - Kirim alert ke Slack/Telegram/Discord on failure
+   - Kirim daily summary report
+   - Configurable notification level (failure only / all)
+
+3. **Exit Code Convention** (untuk monitoring tools seperti Nagios/Zabbix):
+   - `0` = OK, semua backup fresh
+   - `1` = WARNING, beberapa backup mendekati threshold
+   - `2` = CRITICAL, backup expired/missing
+
+#### Config Schema
+```yaml
+backup:
+  monitoring:
+    freshness_threshold: 24h   # alert jika backup > 24 jam
+    disk_space_warning: 10GB   # warning jika sisa disk < 10GB
+    disk_space_critical: 2GB   # critical jika sisa disk < 2GB
+    notifications:
+      enabled: false
+      webhook_url: ""          # Slack/Telegram/Discord webhook
+      on_failure: true
+      on_success: false
+      daily_summary: true
+      summary_time: "08:00"
+```
+
+#### CLI Commands
+```bash
+# Health check
+sfdbtools backup health
+sfdbtools backup health --db dbsf_biznet_jtrust
+sfdbtools backup health --nagios   # output Nagios-compatible
+
+# Disk check
+sfdbtools backup disk-check --dir /media/ArchiveDB
+
+# Send test notification
+sfdbtools backup notify test
+```
+
+#### Proposed File Structure
+```
+internal/app/backup/
+├── health/
+│   ├── checker.go       # Health check engine
+│   ├── freshness.go     # Backup freshness validation
+│   ├── disk.go          # Disk space checker
+│   ├── nagios.go        # Nagios/monitoring exit codes
+│   └── notify/
+│       ├── webhook.go   # Generic webhook sender
+│       ├── slack.go     # Slack formatting
+│       └── telegram.go  # Telegram formatting
+cmd/backup/
+├── health.go            # CLI command
+```
+
+---
+
+### Feature 5: Smart Backup Rotation & Lifecycle (GFS)
+**Priority: 🟡 High** · **Complexity: Medium**
+
+> *"Saya ingin simpan 7 daily, 4 weekly, 3 monthly — seperti GFS."*
+
+Saat ini cleanup hanya berdasarkan `retention_days`. DBA butuh Grandfather-Father-Son rotation.
+
+#### Key Capabilities
+1. **GFS Rotation Strategy**:
+   - Daily: keep last N days
+   - Weekly: keep last N weeks (backup hari tertentu)
+   - Monthly: keep last N months (backup tanggal tertentu)
+
+2. **Smart Cleanup**:
+   - Jangan hapus backup yang menjadi base dari incremental chain
+   - Jangan hapus backup terakhir (failsafe)
+   - Dry-run mode untuk preview sebelum delete
+   - Generate cleanup report (apa yang akan dihapus dan mengapa)
+
+3. **Per-Database Retention** — Override retention per database:
+   - Database critical (production) = longer retention
+   - Database dev/staging = shorter retention
+
+#### Config Schema
+```yaml
+backup:
+  rotation:
+    strategy: gfs          # simple (days only), gfs
+    daily:
+      keep: 7
+    weekly:
+      keep: 4
+      day: sunday          # hari referensi
+    monthly:
+      keep: 3
+      day: 1               # tanggal referensi
+    protect_last_backup: true  # never delete the very last backup
+    per_database:
+      dbsf_production:
+        daily_keep: 14
+        monthly_keep: 6
+```
+
+#### CLI Commands
+```bash
+# Preview rotation
+sfdbtools backup rotate --dry-run --dir /media/ArchiveDB
+
+# Execute rotation
+sfdbtools backup rotate --dir /media/ArchiveDB
+
+# Override per database
+sfdbtools backup rotate --db dbsf_production --keep-daily 14
+```
+
+---
+
+### Feature 6: Point-in-Time Recovery (PITR) Support
+**Priority: 🟢 Medium** · **Complexity: High**
+
+> *"Ada data terhapus jam 14:30, saya perlu restore ke jam 14:29."*
+
+#### Key Capabilities
+1. **Binlog Backup** — Otomatis backup binlog files:
+   - `mariadb-binlog --read-from-remote-server`
+   - Continuous binlog streaming
+   - Binlog rotation tracking
+
+2. **PITR Restore**:
+   - Restore full backup + replay binlog sampai timestamp tertentu
+   - `--stop-datetime` support
+   - `--stop-position` support (GTID-based)
+
+3. **PITR Chain Validation**:
+   - Cek apakah ada gap di binlog chain
+   - Verify GTID continuity dari full backup ke binlog terbaru
+
+#### CLI Commands
+```bash
+# Backup binlog
+sfdbtools backup binlog --profile source.cnf.enc --output /backup/binlog/
+
+# PITR restore
+sfdbtools restore pitr --backup <full-backup> --until "2026-04-24 14:29:00"
+sfdbtools restore pitr --backup <full-backup> --gtid "0-1-12345"
+
+# Check PITR capability
+sfdbtools backup pitr-check --profile source.cnf.enc
+```
+
+> **ℹ️ Note:** PITR membutuhkan binlog aktif di MariaDB (`log_bin = ON`).
+> Fitur ini merupakan extension dari GTID capture yang sudah ada (`internal/app/backup/gtid/`).
+
+---
+
+## Implementation Roadmap
+
+### Phase 1 — Foundation (1-2 sesi AI)
+Fitur yang **langsung berguna** dan **independent** dari fitur lain:
+
+| # | Feature | Priority | Effort (AI-assisted) |
+|---|---------|----------|--------|
+| 1 | **Backup Verification & Integrity** | 🔴 Critical | ~1 sesi |
+| 2 | **Backup Catalog & History** | 🔴 Critical | ~1 sesi |
+| 3 | **Scheduler** (systemd timer) | ✅ Selesai | ~1 sesi |
+
+### Phase 2 — Operations (1-2 sesi AI)
+Fitur untuk **daily operations** DBA:
+
+| # | Feature | Priority | Effort (AI-assisted) |
+|---|---------|----------|--------|
+| 4 | **Health Monitoring & Alerting** | 🟡 High | ~1 sesi |
+| 5 | **Smart Rotation (GFS)** | 🟡 High | ~1 sesi |
+
+### Phase 3 — Advanced (2-3 sesi AI)
+Fitur advanced yang butuh **architectural changes**:
+
+| # | Feature | Priority | Effort (AI-assisted) |
+|---|---------|----------|--------|
+| 6 | **Incremental/Differential (mariabackup)** | 🟡 High | ~1-2 sesi |
+| 7 | **PITR (Binlog Backup + Replay)** | 🟢 Medium | ~1-2 sesi |
+
+---
+
+## Open Questions
+
+1. **Catalog Storage** — Prefer JSON file-based (simple, portable) atau SQLite (queryable, scalable)? JSON bisa upgrade ke SQLite nanti.
+2. **Incremental Backup** — Apakah `mariabackup` sudah terinstall di production servers? Atau mau tetap fokus di `mariadb-dump` saja?
+3. **Notification** — Webhook generic sudah cukup, atau butuh native integration (Slack App, Telegram Bot)?
+4. **PITR** — Apakah binlog sudah aktif di semua production MariaDB? Apakah ada kebutuhan PITR yang mendesak?
+5. **Feature Priority** — Dari 6 fitur di atas, mana yang paling urgent untuk dikerjakan duluan?
+
+---
+
+## Summary: Minimum Viable untuk Production-Grade
+
+```
+✅ Sudah ada:  Backup + Compress + Encrypt + GTID + Grants + Retry + Cleanup + Scheduler (systemd timer)
+
+
+📋 HARUS ADA (Phase 1):
+   1. Backup Verification (checksum + header/footer)
+   2. Backup Catalog (list + search + report)
+
+📋 SANGAT DIBUTUHKAN (Phase 2):
+   3. Health Monitoring (freshness check + alerting)
+   4. GFS Rotation (smart cleanup)
+
+📋 NICE TO HAVE (Phase 3):
+   5. Incremental Backup (mariabackup)
+   6. PITR (binlog backup + replay)
+```

--- a/internal/app/backup/bridges.go
+++ b/internal/app/backup/bridges.go
@@ -36,7 +36,7 @@ func (s *Service) handleSingleModeSetup(ctx context.Context, client interface {
 // =============================================================================
 
 func (s *Service) SetupBackupExecution(state *BackupExecutionState) error {
-	return setup.New(s.Log, s.Config, s.BackupDBOptions, &state.ExcludedDatabases).SetupBackupExecution()
+	return setup.New(s.Log, s.Config, s.BackupDBOptions, state).SetupBackupExecution()
 }
 
 // PrepareBackupSession bridge to setup.PrepareBackupSession.
@@ -48,7 +48,7 @@ func (s *Service) PrepareBackupSession(ctx context.Context, state *BackupExecuti
 	pathGenerator := func(ctx context.Context, client *database.Client, dbFiltered []string) ([]string, error) {
 		return s.GenerateBackupPaths(ctx, state, client, dbFiltered)
 	}
-	return setup.New(s.Log, s.Config, s.BackupDBOptions, &state.ExcludedDatabases).
+	return setup.New(s.Log, s.Config, s.BackupDBOptions, state).
 		PrepareBackupSession(ctx, headerTitle, nonInteractive, pathGenerator)
 }
 

--- a/internal/app/backup/cleanup_critical.go
+++ b/internal/app/backup/cleanup_critical.go
@@ -41,13 +41,23 @@ func criticalCleanup(state *BackupExecutionState, logger applog.Logger) {
 		} else {
 			logger.Debugf("✓ Partial backup file terhapus: %s", currentFile)
 		}
-		state.ClearCurrentBackupFile()
-	}
 
-	// 2. Cleanup additional resources via state's Cleanup method
-	// Ini akan cleanup resources yang di-register via EnableCleanup()
-	// Contoh: lock files, temp directories, dll
-	state.Cleanup()
+		// Hapus metadata file jika ada (menghindari orphaned metadata)
+		metaFile := currentFile + ".meta.json"
+		if err := os.Remove(metaFile); err != nil {
+			logger.Debugf("Gagal menghapus metadata file (mungkin belum dibuat): %v", err)
+		} else {
+			logger.Debugf("✓ Metadata file terhapus: %s", metaFile)
+		}
+
+		// Panggil Cleanup dari state (berisi logika spesifik tambahan) SEBELUM state dibersihkan
+		state.Cleanup()
+
+		state.ClearCurrentBackupFile()
+	} else {
+		// Jika tidak ada current file, tetap panggil Cleanup untuk resources lain
+		state.Cleanup()
+	}
 
 	logger.Debug("Critical cleanup selesai")
 }

--- a/internal/app/backup/execution/builder.go
+++ b/internal/app/backup/execution/builder.go
@@ -17,7 +17,7 @@ import (
 )
 
 // maskDumpArgsForLog menghindari kebocoran kredensial saat menampilkan dump args ke log.
-// Saat ini yang di-mask: --password=... dan form dua-arg "--password" "..."
+// Saat ini yang di-mask: --password=... dan form dua-arg "--password" "..." serta short flag "-p"
 func maskDumpArgsForLog(args []string) []string {
 	if len(args) == 0 {
 		return args
@@ -30,8 +30,12 @@ func maskDumpArgsForLog(args []string) []string {
 			out = append(out, "--password=***")
 			continue
 		}
-		if al == "--password" {
-			out = append(out, "--password")
+		if strings.HasPrefix(al, "-p") && al != "-p" {
+			out = append(out, "-p***")
+			continue
+		}
+		if al == "--password" || al == "-p" {
+			out = append(out, a)
 			// mask next token value if present
 			if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 				out = append(out, "***")

--- a/internal/app/backup/execution/loop.go
+++ b/internal/app/backup/execution/loop.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"sfdbtools/internal/app/backup/model/types_backup"
@@ -76,7 +77,11 @@ func (e *Engine) ExecuteBackupLoop(
 			break
 		}
 
-		e.executeSingleBackupInLoop(ctx, dbName, idx+1, len(databases), config, outputPathFunc, &result)
+		if err := e.executeSingleBackupInLoop(ctx, dbName, idx+1, len(databases), config, outputPathFunc, &result); err != nil {
+			e.Log.Errorf("Menghentikan proses backup karena error kritikal: %v", err)
+			result.Errors = append(result.Errors, "Proses backup dihentikan karena error koneksi/autentikasi fatal")
+			break
+		}
 	}
 
 	return result
@@ -84,6 +89,7 @@ func (e *Engine) ExecuteBackupLoop(
 
 // executeSingleBackupInLoop executes backup untuk satu database dalam loop context.
 // Updates result object dengan success/failure info.
+// Mengembalikan error non-nil jika terjadi error fatal (connection/auth) untuk menghentikan loop.
 func (e *Engine) executeSingleBackupInLoop(
 	ctx context.Context,
 	dbName string,
@@ -91,14 +97,14 @@ func (e *Engine) executeSingleBackupInLoop(
 	config types_backup.BackupLoopConfig,
 	outputPathFunc func(string) (string, error),
 	result *types_backup.BackupLoopResult,
-) {
+) error {
 	// Early context check BEFORE starting backup
 	// Mencegah partial backup jika context sudah cancelled
 	select {
 	case <-ctx.Done():
 		e.Log.Warnf("⚠️  Backup cancelled before database %s (context done)", dbName)
 		result.Errors = append(result.Errors, fmt.Sprintf("Backup cancelled before %s", dbName))
-		return
+		return ctx.Err()
 	default:
 		// Context masih aktif, lanjut backup
 	}
@@ -116,7 +122,7 @@ func (e *Engine) executeSingleBackupInLoop(
 			Error:        msg,
 		})
 		result.Failed++
-		return
+		return nil
 	}
 
 	// Execute backup untuk database ini
@@ -135,7 +141,16 @@ func (e *Engine) executeSingleBackupInLoop(
 			Error:        err.Error(),
 		})
 		result.Failed++
-		return
+
+		// Circuit Breaker: jika error terkait koneksi atau autentikasi yang fatal, hentikan loop
+		errStr := strings.ToLower(err.Error())
+		if strings.Contains(errStr, "access denied") ||
+			strings.Contains(errStr, "connection refused") ||
+			strings.Contains(errStr, "can't connect") ||
+			strings.Contains(errStr, "unknown server") {
+			return fmt.Errorf("fatal connection/auth error: %w", err)
+		}
+		return nil
 	}
 
 	result.BackupInfos = append(result.BackupInfos, backupInfo)
@@ -155,4 +170,6 @@ func (e *Engine) executeSingleBackupInLoop(
 			}
 		}
 	}
+
+	return nil
 }

--- a/internal/app/backup/execution/retry.go
+++ b/internal/app/backup/execution/retry.go
@@ -246,9 +246,23 @@ func removeFlagArg(args []string, candidate string, rawToken string) ([]string, 
 		removed := arg
 
 		// Jika opsi dalam format dua-arg ("--opt" "value"), hapus value juga
+		// Hati-hati jangan sampai menelan argumen posisional (nama database) yang berada di akhir.
+		isNextArgPositional := false
+		if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			allRemainingNonFlags := true
+			for j := i + 1; j < len(args); j++ {
+				if strings.HasPrefix(args[j], "-") {
+					allRemainingNonFlags = false
+					break
+				}
+			}
+			isNextArgPositional = allRemainingNonFlags
+		}
+
 		removeNextValue := !strings.Contains(arg, "=") &&
 			i+1 < len(args) &&
-			!strings.HasPrefix(args[i+1], "-")
+			!strings.HasPrefix(args[i+1], "-") &&
+			!isNextArgPositional
 
 		out := make([]string, 0, len(args))
 		out = append(out, args[:i]...)

--- a/internal/app/backup/grants/grants.go
+++ b/internal/app/backup/grants/grants.go
@@ -5,13 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"sfdbtools/internal/app/backup/metadata"
 	"sfdbtools/internal/app/usersgrants"
 	applog "sfdbtools/internal/services/log"
 	"sfdbtools/internal/shared/database"
+	"sfdbtools/internal/shared/fsops"
 )
 
 func defaultSystemUsers() []string {
@@ -54,21 +54,6 @@ func formatDatabasesForError(databases []string) string {
 	}
 	head := strings.Join(databases[:max], ",")
 	return fmt.Sprintf("%s,...(+%d)", head, len(databases)-max)
-}
-
-// parseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode.
-// Jika parsing gagal atau permissions kosong, return default 0600 (lebih restrictive).
-func parseFilePermissions(permStr string, logger applog.Logger) os.FileMode {
-	const defaultPerm = 0600
-	if strings.TrimSpace(permStr) == "" {
-		return defaultPerm
-	}
-	perm, err := strconv.ParseUint(strings.TrimSpace(permStr), 8, 32)
-	if err != nil {
-		logger.Warnf("Invalid metadata_permissions '%s', using default 0600: %v", permStr, err)
-		return defaultPerm
-	}
-	return os.FileMode(perm)
 }
 
 // ExportUserGrantsIfNeeded exports user grants unless excluded or in dry-run.
@@ -142,7 +127,7 @@ func ExportUserGrantsIfNeeded(
 
 		// Naming: karena isinya user definition, kita pakai _users.sql
 		userDefPath := metadata.GenerateUserDefinitionFilePath(referenceBackupFile)
-		perm := parseFilePermissions(metadataPermissions, log)
+		perm := fsops.ParseFilePermissions(metadataPermissions, 0600, log)
 		if err := os.WriteFile(userDefPath, []byte(sqlText), perm); err != nil {
 			log.Errorf("Gagal menulis file user definitions: %v", err)
 			return "", "", nil
@@ -180,7 +165,7 @@ func ExportUserGrantsIfNeeded(
 		return "", "", handleExportError(err, databases, requireGrants, log)
 	}
 
-	perm := parseFilePermissions(metadataPermissions, log)
+	perm := fsops.ParseFilePermissions(metadataPermissions, 0600, log)
 
 	// Write Users
 	userDefPath := metadata.GenerateUserDefinitionFilePath(referenceBackupFile)
@@ -222,8 +207,7 @@ func handleExportError(err error, databases []string, requireGrants bool, log ap
 
 // UpdateMetadataUserGrantsPath updates backup metadata with the actual user grants file path.
 func UpdateMetadataUserGrantsPath(log applog.Logger, backupFilePath string, userDefPath string, userGrantsPath string, permissions string) {
-	// Kita reuse key UserGrantsFile di metadata untuk path grants.
-	// Jika userDefPath ada, kita mungkin perlu method update baru atau update manual.
-	// TODO: Pastikan method di metadata.Updater support path tambahan atau kita update satu-satu.
-	// Saat ini hanya stub karena engine.go yang memanggil method ini perlu diupdate juga.
+	if err := metadata.UpdateMetadataUserFiles(backupFilePath, userDefPath, userGrantsPath, permissions, log); err != nil {
+		log.Warnf("Gagal mengupdate path file user/grants ke metadata: %v", err)
+	}
 }

--- a/internal/app/backup/metadata/updater.go
+++ b/internal/app/backup/metadata/updater.go
@@ -14,8 +14,8 @@ import (
 	"sfdbtools/internal/shared/consts"
 )
 
-// UpdateMetadataUserGrantsFile membaca metadata yang ada, update UserGrantsFile field, dan save kembali
-func UpdateMetadataUserGrantsFile(backupFilePath string, userGrantsPath string, permissions string, logger applog.Logger) error {
+// UpdateMetadataUserFiles membaca metadata yang ada, update UserGrantsFile dan UserDefinitionFile field, dan save kembali
+func UpdateMetadataUserFiles(backupFilePath string, userDefPath string, userGrantsPath string, permissions string, logger applog.Logger) error {
 	manifestPath := backupFilePath + consts.ExtMetaJSON
 
 	// Baca metadata yang ada
@@ -35,6 +35,13 @@ func UpdateMetadataUserGrantsFile(backupFilePath string, userGrantsPath string, 
 		meta.UserGrantsFile = "none"
 	} else {
 		meta.UserGrantsFile = userGrantsPath
+	}
+
+	// Update UserDefinitionFile - jika empty string, set ke "none"
+	if userDefPath == "" {
+		meta.UserDefinitionFile = "none"
+	} else {
+		meta.UserDefinitionFile = userDefPath
 	}
 
 	// Save kembali

--- a/internal/app/backup/metadata/writer.go
+++ b/internal/app/backup/metadata/writer.go
@@ -13,7 +13,7 @@ import (
 	"sfdbtools/internal/app/backup/model/types_backup"
 	applog "sfdbtools/internal/services/log"
 	"sfdbtools/internal/shared/consts"
-	"strconv"
+	"sfdbtools/internal/shared/fsops"
 )
 
 // SaveBackupMetadata menyimpan metadata ke file dengan atomic write
@@ -28,7 +28,7 @@ func SaveBackupMetadata(meta *types_backup.BackupMetadata, permissions string, l
 	tmpManifest := manifestPath + consts.ExtTmp
 
 	// Parse permissions string to os.FileMode
-	perm := parseFilePermissions(permissions, logger)
+	perm := fsops.ParseFilePermissions(permissions, 0600, logger)
 
 	// Marshal metadata to JSON
 	manifestBytes, err := json.MarshalIndent(meta, "", "  ")
@@ -71,23 +71,4 @@ func TrySaveBackupMetadata(meta *types_backup.BackupMetadata, permissions string
 	}
 
 	return path
-}
-
-// parseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode
-// Jika parsing gagal atau permissions kosong, return default 0600 (lebih restrictive)
-func parseFilePermissions(permStr string, logger applog.Logger) os.FileMode {
-	const defaultPerm = 0600
-
-	if permStr == "" {
-		return defaultPerm
-	}
-
-	// Parse octal string to uint32
-	perm, err := strconv.ParseUint(permStr, 8, 32)
-	if err != nil {
-		logger.Warnf("Invalid metadata_permissions '%s', using default 0600: %v", permStr, err)
-		return defaultPerm
-	}
-
-	return os.FileMode(perm)
 }

--- a/internal/app/backup/modes/iterative.go
+++ b/internal/app/backup/modes/iterative.go
@@ -91,7 +91,7 @@ func (e *IterativeExecutor) Execute(ctx context.Context, dbList []string) types_
 
 		if isSinglePrimaryPackage(dbList) {
 			e.generateCombinedMetadata(loopResult, dbList)
-			res.BackupInfo = e.aggregateBackupInfos(loopResult.BackupInfos)
+			res.BackupInfo = e.aggregateBackupInfos(loopResult.BackupInfos, dbList)
 		}
 	}
 
@@ -165,16 +165,24 @@ func (e *IterativeExecutor) createOutputPathFunc(dbList []string) func(string) (
 
 // aggregateBackupInfos menggabungkan multiple backup infos menjadi satu entry
 // Digunakan untuk primary/secondary yang backup multiple databases tapi display sebagai satu
-func (e *IterativeExecutor) aggregateBackupInfos(backupInfos []types_backup.DatabaseBackupInfo) []types_backup.DatabaseBackupInfo {
+func (e *IterativeExecutor) aggregateBackupInfos(backupInfos []types_backup.DatabaseBackupInfo, dbList []string) []types_backup.DatabaseBackupInfo {
 	if len(backupInfos) == 0 {
 		return backupInfos
 	}
 
-	// Ambil info pertama sebagai base
-	aggregated := backupInfos[0]
+	primaryIndex := 0
+	for i, info := range backupInfos {
+		if len(dbList) > 0 && info.DatabaseName == dbList[0] {
+			primaryIndex = i
+			break
+		}
+	}
+
+	// Ambil info utama sebagai base
+	aggregated := backupInfos[primaryIndex]
 
 	// Update database name untuk menunjukkan multiple databases
-	aggregated.DatabaseName = fmt.Sprintf("%s + %d companion databases", backupInfos[0].DatabaseName, len(backupInfos)-1)
+	aggregated.DatabaseName = fmt.Sprintf("%s + %d companion databases", aggregated.DatabaseName, len(backupInfos)-1)
 
 	// Sum up file sizes dari semua backup
 	totalSize := int64(0)
@@ -184,8 +192,8 @@ func (e *IterativeExecutor) aggregateBackupInfos(backupInfos []types_backup.Data
 	aggregated.FileSize = totalSize
 	aggregated.FileSizeHuman = fmt.Sprintf("%.2f MB", float64(totalSize)/(1024*1024))
 
-	// Metadata file adalah dari database pertama (combined metadata)
-	aggregated.ManifestFile = backupInfos[0].OutputFile + consts.ExtMetaJSON
+	// Metadata file adalah dari database yang terpilih sebagai base
+	aggregated.ManifestFile = aggregated.OutputFile + consts.ExtMetaJSON
 
 	return []types_backup.DatabaseBackupInfo{aggregated}
 }
@@ -200,23 +208,32 @@ func (e *IterativeExecutor) generateCombinedMetadata(loopResult types_backup.Bac
 
 	e.service.GetLog().Debug(fmt.Sprintf("Generating combined metadata untuk %d databases", len(dbList)))
 
+	// Cari primary file, prioritas pada index asli primary db
+	primaryIndex := 0
+	for i, info := range loopResult.BackupInfos {
+		if len(dbList) > 0 && info.DatabaseName == dbList[0] {
+			primaryIndex = i
+			break
+		}
+	}
+
 	// Untuk primary/secondary:
 	// 1. Update metadata pertama dengan DatabaseNames dan DatabaseDetails (info lengkap per database)
 	// 2. Hapus semua metadata individual untuk companion databases
 
-	// Update metadata pertama dengan full database list dan details
-	primaryBackupFile := loopResult.BackupInfos[0].OutputFile
+	// Update metadata utama dengan full database list dan details
+	primaryBackupFile := loopResult.BackupInfos[primaryIndex].OutputFile
 	permissions := e.service.GetConfig().Backup.Output.MetadataPermissions
 	if err := metadata.UpdateMetadataWithDatabaseDetails(primaryBackupFile, dbList, loopResult.BackupInfos, permissions, e.service.GetLog()); err != nil {
 		e.service.GetLog().Warn("Gagal update combined metadata: " + err.Error())
 	}
 
-	// Hapus metadata individual untuk companion databases (index 1+)
+	// Hapus metadata individual untuk database lainnya
 	for i, info := range loopResult.BackupInfos {
-		if i == 0 {
+		if i == primaryIndex {
 			continue
 		}
-		// Companion databases: hapus metadata individual
+		// Hapus metadata individual
 		metadataPath := info.OutputFile + consts.ExtMetaJSON
 		e.service.GetLog().Debug("Menghapus metadata companion: " + metadataPath)
 		os.Remove(metadataPath)

--- a/internal/app/backup/scheduler/cron_parser.go
+++ b/internal/app/backup/scheduler/cron_parser.go
@@ -1,0 +1,54 @@
+package scheduler
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConvertCronToSystemd translates a basic 5-column cron expression to systemd OnCalendar format.
+func ConvertCronToSystemd(cronExpr string) (string, error) {
+	fields := strings.Fields(strings.TrimSpace(cronExpr))
+	if len(fields) != 5 {
+		return "", fmt.Errorf("invalid cron expression: expected 5 fields, got %d", len(fields))
+	}
+
+	minute := fields[0]
+	hour := fields[1]
+	dom := fields[2]
+	month := fields[3]
+	dow := fields[4]
+
+	// Systemd format: DayOfWeek Year-Month-Day Hour:Minute:Second
+
+	// Convert Day of Week
+	sysDow := ""
+	if dow != "*" {
+		sysDow = dow + " "
+	}
+
+	sysMonth := month
+	sysDom := dom
+	if strings.HasPrefix(dom, "*/") {
+		step := strings.TrimPrefix(dom, "*/")
+		sysDom = "1/" + step
+	}
+
+	sysHour := hour
+	if hour != "*" && !strings.HasPrefix(hour, "*/") && len(sysHour) == 1 {
+		sysHour = "0" + sysHour
+	} else if strings.HasPrefix(hour, "*/") {
+		step := strings.TrimPrefix(hour, "*/")
+		sysHour = "0/" + step
+	}
+
+	sysMinute := minute
+	if minute != "*" && !strings.HasPrefix(minute, "*/") && len(sysMinute) == 1 {
+		sysMinute = "0" + sysMinute
+	} else if strings.HasPrefix(minute, "*/") {
+		step := strings.TrimPrefix(minute, "*/")
+		sysMinute = "0/" + step
+	}
+
+	onCalendar := fmt.Sprintf("%s*-%s-%s %s:%s:00", sysDow, sysMonth, sysDom, sysHour, sysMinute)
+	return onCalendar, nil
+}

--- a/internal/app/backup/scheduler/cron_parser_test.go
+++ b/internal/app/backup/scheduler/cron_parser_test.go
@@ -1,0 +1,52 @@
+package scheduler
+
+import (
+	"testing"
+)
+
+func TestConvertCronToSystemd(t *testing.T) {
+	tests := []struct {
+		name     string
+		cronExpr string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "Daily at 2 AM",
+			cronExpr: "0 2 * * *",
+			expected: "*-*-* 02:00:00",
+			wantErr:  false,
+		},
+		{
+			name:     "Every 3 days at 1 AM",
+			cronExpr: "0 1 */3 * *",
+			expected: "*-*-1/3 01:00:00",
+			wantErr:  false,
+		},
+		{
+			name:     "Every Monday at 3:30",
+			cronExpr: "30 3 * * Mon",
+			expected: "Mon *-*-* 03:30:00",
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid cron",
+			cronExpr: "0 2 * *",
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertCronToSystemd(tt.cronExpr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ConvertCronToSystemd() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("ConvertCronToSystemd() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/app/backup/scheduler/manager.go
+++ b/internal/app/backup/scheduler/manager.go
@@ -30,6 +30,7 @@ type TemplateData struct {
 	JobName     string
 	ExecPath    string
 	Mode        string
+	OutputMode  string
 	Ticket      string
 	Profile     string
 	IncludeFile string
@@ -92,6 +93,7 @@ func (m *Manager) Sync(ctx context.Context) error {
 			JobName:     job.Name,
 			ExecPath:    execPath,
 			Mode:        job.Mode,
+			OutputMode:  job.OutputMode,
 			Ticket:      job.Ticket,
 			Profile:     job.Profile,
 			IncludeFile: job.IncludeFile,

--- a/internal/app/backup/scheduler/manager.go
+++ b/internal/app/backup/scheduler/manager.go
@@ -1,0 +1,146 @@
+package scheduler
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	appconfig "sfdbtools/internal/services/config"
+	applog "sfdbtools/internal/services/log"
+)
+
+type Manager struct {
+	Config  *appconfig.Config
+	Log     applog.Logger
+	Systemd *SystemdManager
+}
+
+func NewManager(cfg *appconfig.Config, log applog.Logger) *Manager {
+	return &Manager{
+		Config:  cfg,
+		Log:     log,
+		Systemd: NewSystemdManager(),
+	}
+}
+
+type TemplateData struct {
+	JobName     string
+	ExecPath    string
+	Mode        string
+	Ticket      string
+	Profile     string
+	IncludeFile string
+	OutputDir   string
+	OnCalendar  string
+}
+
+func (m *Manager) Sync(ctx context.Context) error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	systemdDir := "/etc/systemd/system"
+	if _, err := os.Stat(systemdDir); os.IsNotExist(err) {
+		return fmt.Errorf("systemd directory %s does not exist, scheduling might not be supported on this system", systemdDir)
+	}
+
+	serviceTmpl, err := template.New("service").Parse(serviceTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse service template: %w", err)
+	}
+
+	timerTmpl, err := template.New("timer").Parse(timerTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to parse timer template: %w", err)
+	}
+
+	m.Log.Info("Syncing scheduler jobs to systemd...")
+
+	// To keep track of generated timers for cleanup if a job is removed (future enhancement)
+	// For now, we'll just generate/enable what's in the config.
+
+	for _, job := range m.Config.Backup.Scheduler.Jobs {
+		if job.Name == "" {
+			m.Log.Warn("Found job with empty name, skipping...")
+			continue
+		}
+
+		serviceName := fmt.Sprintf("sfdbtools-backup-%s.service", job.Name)
+		timerName := fmt.Sprintf("sfdbtools-backup-%s.timer", job.Name)
+		
+		servicePath := filepath.Join(systemdDir, serviceName)
+		timerPath := filepath.Join(systemdDir, timerName)
+
+		if !job.Enabled {
+			// Disable timer if it exists
+			m.Log.Infof("Job '%s' is disabled, ensuring timer is stopped...", job.Name)
+			m.Systemd.DisableAndStopTimer(ctx, timerName)
+			continue
+		}
+
+		onCalendar, err := ConvertCronToSystemd(job.Schedule)
+		if err != nil {
+			m.Log.Warnf("Failed to parse schedule for job '%s': %v", job.Name, err)
+			continue
+		}
+
+		data := TemplateData{
+			JobName:     job.Name,
+			ExecPath:    execPath,
+			Mode:        job.Mode,
+			Ticket:      job.Ticket,
+			Profile:     job.Profile,
+			IncludeFile: job.IncludeFile,
+			OutputDir:   job.Output.BaseDirectory,
+			OnCalendar:  onCalendar,
+		}
+
+		// Generate Service File
+		var svcBuf bytes.Buffer
+		if err := serviceTmpl.Execute(&svcBuf, data); err != nil {
+			m.Log.Errorf("Failed to execute service template for job '%s': %v", job.Name, err)
+			continue
+		}
+		if err := os.WriteFile(servicePath, svcBuf.Bytes(), 0644); err != nil {
+			m.Log.Errorf("Failed to write service file for job '%s': %v", job.Name, err)
+			continue
+		}
+
+		// Generate Timer File
+		var tmrBuf bytes.Buffer
+		if err := timerTmpl.Execute(&tmrBuf, data); err != nil {
+			m.Log.Errorf("Failed to execute timer template for job '%s': %v", job.Name, err)
+			continue
+		}
+		if err := os.WriteFile(timerPath, tmrBuf.Bytes(), 0644); err != nil {
+			m.Log.Errorf("Failed to write timer file for job '%s': %v", job.Name, err)
+			continue
+		}
+
+		m.Log.Infof("Generated systemd units for job '%s'", job.Name)
+	}
+
+	m.Log.Info("Reloading systemd daemon...")
+	if err := m.Systemd.DaemonReload(ctx); err != nil {
+		m.Log.Warnf("Failed to reload systemd daemon: %v", err)
+	}
+
+	// Enable and start timers
+	for _, job := range m.Config.Backup.Scheduler.Jobs {
+		if !job.Enabled {
+			continue
+		}
+		timerName := fmt.Sprintf("sfdbtools-backup-%s.timer", job.Name)
+		m.Log.Infof("Enabling and starting timer for job '%s'...", job.Name)
+		if err := m.Systemd.EnableAndStartTimer(ctx, timerName); err != nil {
+			m.Log.Errorf("Failed to enable/start timer for job '%s': %v", job.Name, err)
+		}
+	}
+
+	m.Log.Info("Scheduler sync complete.")
+	return nil
+}

--- a/internal/app/backup/scheduler/status.go
+++ b/internal/app/backup/scheduler/status.go
@@ -10,6 +10,34 @@ import (
 	"sfdbtools/internal/ui/table"
 )
 
+// getTimerProperty queries a specific property from a systemd timer using systemctl show.
+func getTimerProperty(ctx context.Context, timerName, property string) string {
+	cmd := exec.CommandContext(ctx, "systemctl", "show", timerName, "--property="+property, "--value")
+	out, err := cmd.Output()
+	if err != nil {
+		return "-"
+	}
+	val := strings.TrimSpace(string(out))
+	if val == "" || val == "0" || val == "n/a" {
+		return "-"
+	}
+	return val
+}
+
+// getServiceProperty queries a specific property from a systemd service using systemctl show.
+func getServiceProperty(ctx context.Context, serviceName, property string) string {
+	cmd := exec.CommandContext(ctx, "systemctl", "show", serviceName, "--property="+property, "--value")
+	out, err := cmd.Output()
+	if err != nil {
+		return "-"
+	}
+	val := strings.TrimSpace(string(out))
+	if val == "" || val == "0" || val == "n/a" {
+		return "-"
+	}
+	return val
+}
+
 // ShowStatus displays the status of all configured backup jobs
 func (m *Manager) ShowStatus(ctx context.Context) error {
 	if len(m.Config.Backup.Scheduler.Jobs) == 0 {
@@ -17,7 +45,7 @@ func (m *Manager) ShowStatus(ctx context.Context) error {
 		return nil
 	}
 
-	headers := []string{"Job Name", "Enabled (YAML)", "Schedule (Cron)", "Systemd Timer Status"}
+	headers := []string{"Job Name", "Enabled", "Schedule (Cron)", "Timer Status", "Next Run", "Last Trigger", "Last Result"}
 	var rows [][]string
 
 	for _, job := range m.Config.Backup.Scheduler.Jobs {
@@ -31,16 +59,41 @@ func (m *Manager) ShowStatus(ctx context.Context) error {
 		}
 
 		timerName := fmt.Sprintf("sfdbtools-backup-%s.timer", job.Name)
-		
-		// Check systemd status
+		serviceName := fmt.Sprintf("sfdbtools-backup-%s.service", job.Name)
+
+		// Timer active status
 		statusCmd := exec.CommandContext(ctx, "systemctl", "is-active", timerName)
-		output, _ := statusCmd.CombinedOutput()
-		sysStatus := strings.TrimSpace(string(output))
-		
-		if sysStatus == "active" {
-			sysStatus = "Active"
-		} else if sysStatus == "inactive" {
+		statusOut, _ := statusCmd.CombinedOutput()
+		sysStatus := strings.TrimSpace(string(statusOut))
+		switch sysStatus {
+		case "active":
+			sysStatus = "Active ✓"
+		case "inactive":
 			sysStatus = "Inactive"
+		case "failed":
+			sysStatus = "Failed ✗"
+		default:
+			sysStatus = "Not Found"
+		}
+
+		// Next scheduled run (from timer)
+		nextRun := getTimerProperty(ctx, timerName, "NextElapseUSecRealtime")
+		if nextRun == "-" {
+			nextRun = getTimerProperty(ctx, timerName, "NextElapseUSec")
+		}
+
+		// Last time timer triggered
+		lastTrigger := getTimerProperty(ctx, timerName, "LastTriggerUSec")
+
+		// Last service execution result
+		lastResult := getServiceProperty(ctx, serviceName, "Result")
+		switch lastResult {
+		case "success":
+			lastResult = "success ✓"
+		case "exit-code":
+			lastResult = "failed ✗"
+		case "-":
+			lastResult = "never run"
 		}
 
 		rows = append(rows, []string{
@@ -48,13 +101,35 @@ func (m *Manager) ShowStatus(ctx context.Context) error {
 			enabled,
 			job.Schedule,
 			sysStatus,
+			nextRun,
+			lastTrigger,
+			lastResult,
 		})
 	}
 
 	print.PrintSubHeader("Status Scheduler Backup (Systemd Timers)")
 	table.Render(headers, rows)
-	
-	m.Log.Info("Untuk melihat waktu eksekusi (Next Run), jalankan: systemctl list-timers | grep sfdbtools")
-	
+
+	// Print actionable log commands per job
+	fmt.Println()
+	fmt.Println("  📖 Cara memantau & memverifikasi job:")
+	fmt.Println()
+	for _, job := range m.Config.Backup.Scheduler.Jobs {
+		if job.Name == "" {
+			continue
+		}
+		serviceName := fmt.Sprintf("sfdbtools-backup-%s.service", job.Name)
+		fmt.Printf("  [%s]\n", job.Name)
+		fmt.Printf("    Lihat log terakhir  : journalctl -u %s -n 50 --no-pager\n", serviceName)
+		fmt.Printf("    Pantau real-time    : journalctl -f -u %s\n", serviceName)
+		fmt.Printf("    Cek hasil eksekusi  : systemctl status %s\n", serviceName)
+		fmt.Printf("    Jalankan manual     : systemctl start %s\n", serviceName)
+		fmt.Println()
+	}
+
+	fmt.Println("  ⏱  Semua timer aktif:")
+	fmt.Println("    systemctl list-timers | grep sfdbtools")
+	fmt.Println()
+
 	return nil
 }

--- a/internal/app/backup/scheduler/status.go
+++ b/internal/app/backup/scheduler/status.go
@@ -1,0 +1,60 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"sfdbtools/internal/ui/print"
+	"sfdbtools/internal/ui/table"
+)
+
+// ShowStatus displays the status of all configured backup jobs
+func (m *Manager) ShowStatus(ctx context.Context) error {
+	if len(m.Config.Backup.Scheduler.Jobs) == 0 {
+		m.Log.Info("Tidak ada konfigurasi job scheduler di config.yaml.")
+		return nil
+	}
+
+	headers := []string{"Job Name", "Enabled (YAML)", "Schedule (Cron)", "Systemd Timer Status"}
+	var rows [][]string
+
+	for _, job := range m.Config.Backup.Scheduler.Jobs {
+		if job.Name == "" {
+			continue
+		}
+
+		enabled := "No"
+		if job.Enabled {
+			enabled = "Yes"
+		}
+
+		timerName := fmt.Sprintf("sfdbtools-backup-%s.timer", job.Name)
+		
+		// Check systemd status
+		statusCmd := exec.CommandContext(ctx, "systemctl", "is-active", timerName)
+		output, _ := statusCmd.CombinedOutput()
+		sysStatus := strings.TrimSpace(string(output))
+		
+		if sysStatus == "active" {
+			sysStatus = "Active"
+		} else if sysStatus == "inactive" {
+			sysStatus = "Inactive"
+		}
+
+		rows = append(rows, []string{
+			job.Name,
+			enabled,
+			job.Schedule,
+			sysStatus,
+		})
+	}
+
+	print.PrintSubHeader("Status Scheduler Backup (Systemd Timers)")
+	table.Render(headers, rows)
+	
+	m.Log.Info("Untuk melihat waktu eksekusi (Next Run), jalankan: systemctl list-timers | grep sfdbtools")
+	
+	return nil
+}

--- a/internal/app/backup/scheduler/systemd.go
+++ b/internal/app/backup/scheduler/systemd.go
@@ -1,0 +1,28 @@
+package scheduler
+
+import (
+	"context"
+	"os/exec"
+)
+
+// SystemdManager handles systemd daemon reloads and service toggles.
+type SystemdManager struct{}
+
+func NewSystemdManager() *SystemdManager {
+	return &SystemdManager{}
+}
+
+func (s *SystemdManager) DaemonReload(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "systemctl", "daemon-reload")
+	return cmd.Run()
+}
+
+func (s *SystemdManager) EnableAndStartTimer(ctx context.Context, timerName string) error {
+	cmd := exec.CommandContext(ctx, "systemctl", "enable", "--now", timerName)
+	return cmd.Run()
+}
+
+func (s *SystemdManager) DisableAndStopTimer(ctx context.Context, timerName string) error {
+	cmd := exec.CommandContext(ctx, "systemctl", "disable", "--now", timerName)
+	return cmd.Run()
+}

--- a/internal/app/backup/scheduler/templates.go
+++ b/internal/app/backup/scheduler/templates.go
@@ -8,7 +8,7 @@ After=network.target
 Type=oneshot
 User=root
 # We use flock to ensure serial execution (no parallel backup jobs running at the same time)
-ExecStart=/usr/bin/flock /var/lock/sfdbtools-global-backup.lock {{ .ExecPath }} backup {{ .Mode }} --quiet --ticket="{{ .Ticket }}" --profile="{{ .Profile }}"{{ if .IncludeFile }} --db-file="{{ .IncludeFile }}"{{ end }} --backup-dir="{{ .OutputDir }}"
+ExecStart=/usr/bin/flock /var/lock/sfdbtools-global-backup.lock {{ .ExecPath }} backup {{ .Mode }} --quiet --ticket="{{ .Ticket }}" --profile="{{ .Profile }}"{{ if .IncludeFile }} --db-file="{{ .IncludeFile }}"{{ end }}{{ if .OutputMode }} --mode="{{ .OutputMode }}"{{ end }} --backup-dir="{{ .OutputDir }}"
 `
 
 const timerTemplate = `[Unit]

--- a/internal/app/backup/scheduler/templates.go
+++ b/internal/app/backup/scheduler/templates.go
@@ -1,0 +1,23 @@
+package scheduler
+
+const serviceTemplate = `[Unit]
+Description=sfDBTools Backup Job - {{ .JobName }}
+After=network.target
+
+[Service]
+Type=oneshot
+User=root
+# We use flock to ensure serial execution (no parallel backup jobs running at the same time)
+ExecStart=/usr/bin/flock /var/lock/sfdbtools-global-backup.lock {{ .ExecPath }} backup {{ .Mode }} --quiet --ticket="{{ .Ticket }}" --profile="{{ .Profile }}"{{ if .IncludeFile }} --db-file="{{ .IncludeFile }}"{{ end }} --backup-dir="{{ .OutputDir }}"
+`
+
+const timerTemplate = `[Unit]
+Description=Timer for sfDBTools Backup Job - {{ .JobName }}
+
+[Timer]
+OnCalendar={{ .OnCalendar }}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`

--- a/internal/app/backup/service.go
+++ b/internal/app/backup/service.go
@@ -35,6 +35,13 @@ type BackupExecutionState struct {
 	mu                sync.Mutex
 }
 
+// SetExcludedDatabases updates the excluded databases list safely
+func (s *BackupExecutionState) SetExcludedDatabases(excluded []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ExcludedDatabases = excluded
+}
+
 // SetCurrentBackupFile mencatat file backup yang sedang dibuat (thread-safe)
 func (s *BackupExecutionState) SetCurrentBackupFile(filePath string) {
 	s.mu.Lock()

--- a/internal/app/backup/setup/config.go
+++ b/internal/app/backup/setup/config.go
@@ -15,15 +15,19 @@ import (
 	"sfdbtools/internal/ui/prompt"
 )
 
-type Setup struct {
-	Log               applog.Logger
-	Config            *appconfig.Config
-	Options           *types_backup.BackupDBOptions
-	ExcludedDatabases *[]string
+type StateUpdater interface {
+	SetExcludedDatabases([]string)
 }
 
-func New(log applog.Logger, cfg *appconfig.Config, opts *types_backup.BackupDBOptions, excluded *[]string) *Setup {
-	return &Setup{Log: log, Config: cfg, Options: opts, ExcludedDatabases: excluded}
+type Setup struct {
+	Log          applog.Logger
+	Config       *appconfig.Config
+	Options      *types_backup.BackupDBOptions
+	StateUpdater StateUpdater
+}
+
+func New(log applog.Logger, cfg *appconfig.Config, opts *types_backup.BackupDBOptions, updater StateUpdater) *Setup {
+	return &Setup{Log: log, Config: cfg, Options: opts, StateUpdater: updater}
 }
 
 // isInteractiveMode adalah source-of-truth tunggal untuk mode-mode backup yang

--- a/internal/app/backup/setup/session.go
+++ b/internal/app/backup/setup/session.go
@@ -96,11 +96,11 @@ func (s *Setup) PrepareBackupSession(ctx context.Context, headerTitle string, no
 			return nil, nil, fmt.Errorf("gagal mendapatkan daftar database: %w", err)
 		}
 
-		if s.Options.Mode == consts.ModeAll && stats != nil && s.ExcludedDatabases != nil {
-			*s.ExcludedDatabases = stats.ExcludedDatabases
-			s.Log.Infof("Menyimpan %d excluded databases untuk metadata", len(*s.ExcludedDatabases))
-			if len(*s.ExcludedDatabases) > 0 {
-				s.Log.Debugf("Excluded databases: %v", *s.ExcludedDatabases)
+		if s.Options.Mode == consts.ModeAll && stats != nil && s.StateUpdater != nil {
+			s.StateUpdater.SetExcludedDatabases(stats.ExcludedDatabases)
+			s.Log.Infof("Menyimpan %d excluded databases untuk metadata", len(stats.ExcludedDatabases))
+			if len(stats.ExcludedDatabases) > 0 {
+				s.Log.Debugf("Excluded databases: %v", stats.ExcludedDatabases)
 			}
 		}
 

--- a/internal/app/backup/writer/engine.go
+++ b/internal/app/backup/writer/engine.go
@@ -197,19 +197,38 @@ func (e *Engine) isFatalDumpError(toolName string, err error, stderrOutput strin
 	return true
 }
 
-// isRetryableError menentukan apakah error bisa di-retry (seperti SSL mismatch)
-// Error yang bisa di-retry tidak perlu log path di writer layer karena akan di-handle di execution layer
-// Fungsi ini menggunakan pattern yang sama dengan execution.IsSSLMismatchRequiredButServerNoSupport
-// untuk konsistensi deteksi retry-able errors
-func (e *Engine) isRetryableError(stderrOutput string) bool {
-	if stderrOutput == "" {
-		return false
+// CappedBuffer limits the amount of data stored to prevent OOM
+type CappedBuffer struct {
+	maxBytes int
+	buffer   []byte
+	overflow bool
+}
+
+func newCappedBuffer(maxBytes int) *CappedBuffer {
+	return &CappedBuffer{
+		maxBytes: maxBytes,
+		buffer:   make([]byte, 0, 1024),
 	}
-	stderrLower := strings.ToLower(stderrOutput)
-	// SSL mismatch adalah retry-able error (pattern sama dengan execution.IsSSLMismatchRequiredButServerNoSupport)
-	return strings.Contains(stderrLower, "tls/ssl error") &&
-		strings.Contains(stderrLower, "ssl is required") &&
-		strings.Contains(stderrLower, "server does not support")
+}
+
+func (c *CappedBuffer) Write(p []byte) (n int, err error) {
+	if len(c.buffer)+len(p) > c.maxBytes {
+		allowed := c.maxBytes - len(c.buffer)
+		if allowed > 0 {
+			c.buffer = append(c.buffer, p[:allowed]...)
+		}
+		c.overflow = true
+	} else {
+		c.buffer = append(c.buffer, p...)
+	}
+	return len(p), nil // Always report successful write of all bytes to not break cmd.Run
+}
+
+func (c *CappedBuffer) String() string {
+	if c.overflow {
+		return string(c.buffer) + "\n... (output truncated due to size limit)"
+	}
+	return string(c.buffer)
 }
 
 // parseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode
@@ -319,8 +338,9 @@ func (e *Engine) ExecuteMysqldumpWithPipe(ctx context.Context, mysqldumpArgs []s
 	monitor := newDatabaseMonitorWriter(writer, spin, e.Log)
 	cmd.Stdout = monitor
 
-	var stderrBuf strings.Builder
-	cmd.Stderr = &stderrBuf
+	// Use CappedBuffer (max 1MB) for stderr to prevent OOM
+	stderrBuf := newCappedBuffer(1 * 1024 * 1024)
+	cmd.Stderr = stderrBuf
 
 	runErr := cmd.Run()
 

--- a/internal/cli/runner/runner.go
+++ b/internal/cli/runner/runner.go
@@ -95,9 +95,10 @@ func logOrPrintErr(cmd *cobra.Command, err error) {
 	}
 	if appdeps.Deps != nil && appdeps.Deps.Logger != nil {
 		appdeps.Deps.Logger.Error(err.Error())
-		return
+	} else {
+		printErr(cmd, err.Error())
 	}
-	printErr(cmd, err.Error())
+	os.Exit(1)
 }
 
 func printErr(cmd *cobra.Command, msg string) {

--- a/internal/services/config/appconfig_types.go
+++ b/internal/services/config/appconfig_types.go
@@ -62,6 +62,32 @@ type BackupConfig struct {
 	Output        OutputConfig       `yaml:"output"`
 	Verification  VerificationConfig `yaml:"verification"`
 	Replication   ReplicationConfig  `yaml:"replication"`
+	Scheduler     SchedulerConfig    `yaml:"scheduler"`
+}
+
+type SchedulerConfig struct {
+	Jobs []BackupJob `yaml:"jobs"`
+}
+
+type BackupJob struct {
+	Name        string           `yaml:"name"`
+	Enabled     bool             `yaml:"enabled"`
+	Schedule    string           `yaml:"schedule"`
+	Mode        string           `yaml:"mode"`
+	IncludeFile string           `yaml:"include_file"`
+	Profile     string           `yaml:"profile"`
+	Ticket      string           `yaml:"ticket"`
+	Output      JobOutputConfig  `yaml:"output"`
+	Cleanup     JobCleanupConfig `yaml:"cleanup"`
+}
+
+type JobOutputConfig struct {
+	BaseDirectory string `yaml:"base_directory"`
+}
+
+type JobCleanupConfig struct {
+	Enabled       bool `yaml:"enabled"`
+	RetentionDays int  `yaml:"retention_days"`
 }
 
 type IncludeConfig struct {

--- a/internal/services/config/appconfig_types.go
+++ b/internal/services/config/appconfig_types.go
@@ -74,6 +74,7 @@ type BackupJob struct {
 	Enabled     bool             `yaml:"enabled"`
 	Schedule    string           `yaml:"schedule"`
 	Mode        string           `yaml:"mode"`
+	OutputMode  string           `yaml:"output_mode"` // Khusus mode filter: "single-file" atau "multi-file"
 	IncludeFile string           `yaml:"include_file"`
 	Profile     string           `yaml:"profile"`
 	Ticket      string           `yaml:"ticket"`

--- a/internal/shared/fsops/permissions.go
+++ b/internal/shared/fsops/permissions.go
@@ -1,0 +1,26 @@
+package fsops
+
+import (
+	"os"
+	"strconv"
+
+	applog "sfdbtools/internal/services/log"
+)
+
+// ParseFilePermissions mengkonversi string permissions (e.g., "0600") ke os.FileMode.
+// Jika parsing gagal atau permissions kosong, return defaultPerm.
+func ParseFilePermissions(permStr string, defaultPerm os.FileMode, logger applog.Logger) os.FileMode {
+	if permStr == "" {
+		return defaultPerm
+	}
+
+	perm, err := strconv.ParseUint(permStr, 8, 32)
+	if err != nil {
+		if logger != nil {
+			logger.Warnf("Invalid file_permissions '%s', using default: %v", permStr, err)
+		}
+		return defaultPerm
+	}
+
+	return os.FileMode(perm)
+}


### PR DESCRIPTION
This PR introduces a robust, OS-level backup scheduler using Systemd Timers and `/var/lock` isolation, driven entirely by the existing `config.yaml` file.

## Key Features
- **YAML-Driven Scheduling:** Users can define multiple jobs (daily, weekly, specific DBs, specific profiles) directly in the `scheduler.jobs` array of their `config.yaml`.
- **Systemd Integration:** Implemented `sfdbtools backup schedule sync` to automatically translate cron expressions into `OnCalendar` strings and generate native `.service` and `.timer` systemd units.
- **Serial Execution Guarantee:** Added a global lock via `flock` inside the generated systemd services to ensure jobs run serially and do not overwhelm server resources (disk I/O or memory) if schedules overlap.
- **Status Dashboard:** Implemented `sfdbtools backup schedule status` to provide a clean CLI table showing YAML definitions versus actual `systemctl` timer statuses.